### PR TITLE
Adding loki and kubecost helm value manifests

### DIFF
--- a/infrastructure/monitoring/helm_manifests/kubecost.yaml
+++ b/infrastructure/monitoring/helm_manifests/kubecost.yaml
@@ -1,0 +1,19076 @@
+---
+# Source: cost-analyzer/charts/grafana/templates/podsecuritypolicy.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: kubecost-grafana
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    heritage: Helm
+    release: kubecost
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+---
+# Source: cost-analyzer/templates/cost-analyzer-psp.template.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+    name: kubecost-cost-analyzer-psp
+    labels:
+
+      app.kubernetes.io/name: cost-analyzer
+      helm.sh/chart: cost-analyzer-1.97.0
+      app.kubernetes.io/instance: kubecost
+      app.kubernetes.io/managed-by: Helm
+      app: cost-analyzer
+spec:
+    privileged: false
+    seLinux:
+        rule: RunAsAny
+    supplementalGroups:
+        rule: RunAsAny
+    runAsUser:
+        rule: RunAsAny
+    fsGroup:
+        rule: RunAsAny
+    volumes:
+        - '*'
+---
+# Source: cost-analyzer/charts/grafana/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    heritage: Helm
+    release: kubecost
+  name: kubecost-grafana
+---
+# Source: cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    helm.sh/chart: kube-state-metrics-2.7.2
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kubecost
+  name: kubecost-kube-state-metrics
+  namespace: kubecost
+imagePullSecrets:
+  []
+---
+# Source: cost-analyzer/charts/prometheus/templates/node-exporter-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: "node-exporter"
+    app: prometheus
+    release: kubecost
+    chart: prometheus-11.0.2
+    heritage: Helm
+  name: kubecost-prometheus-node-exporter
+---
+# Source: cost-analyzer/charts/prometheus/templates/server-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+    release: kubecost
+    chart: prometheus-11.0.2
+    heritage: Helm
+  name: kubecost-prometheus-server
+---
+# Source: cost-analyzer/templates/cost-analyzer-service-account-template.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubecost-cost-analyzer
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+---
+# Source: cost-analyzer/charts/grafana/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubecost-grafana
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    release: kubecost
+    heritage: Helm
+type: Opaque
+data:
+  admin-user: "YWRtaW4="
+  admin-password: "c3Ryb25ncGFzc3dvcmQ="
+  ldap-toml: ""
+---
+# Source: cost-analyzer/charts/grafana/templates/configmap-dashboard-provider.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    release: kubecost
+    heritage: Helm
+  name: kubecost-grafana-config-dashboards
+data:
+  provider.yaml: |-
+    apiVersion: 1
+    providers:
+    - name: 'default'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: false
+      options:
+        path: /tmp/dashboards
+---
+# Source: cost-analyzer/charts/grafana/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubecost-grafana
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    release: kubecost
+    heritage: Helm
+data:
+  grafana.ini: |
+    [analytics]
+    check_for_updates = true
+    [auth.anonymous]
+    enabled = true
+    org_name = Main Org.
+    org_role = Editor
+    [grafana_net]
+    url = https://grafana.net
+    [log]
+    mode = console
+    [paths]
+    data = /var/lib/grafana/data
+    logs = /var/log/grafana
+    plugins = /var/lib/grafana/plugins
+    provisioning = /etc/grafana/provisioning
+    [server]
+    root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+    - access: proxy
+      isDefault: false
+      name: prometheus-kubecost
+      type: prometheus
+      url: http://kubecost-prometheus-server.kubecost.svc.cluster.local
+    - access: proxy
+      isDefault: true
+      name: Prometheus
+      type: prometheus
+      url: http://kubecost-prometheus-server.kubecost.svc
+---
+# Source: cost-analyzer/charts/prometheus/templates/server-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+    release: kubecost
+    chart: prometheus-11.0.2
+    heritage: Helm
+  name: kubecost-prometheus-server
+data:
+  alerting_rules.yml: |
+    {}
+  alerts: |
+    {}
+  prometheus.yml: |
+    global:
+      evaluation_interval: 1m
+      external_labels:
+        cluster_id: cluster-one
+      scrape_interval: 1m
+      scrape_timeout: 10s
+    remote_write:
+    rule_files:
+    - /etc/config/recording_rules.yml
+    - /etc/config/alerting_rules.yml
+    - /etc/config/rules
+    - /etc/config/alerts
+    scrape_configs:
+    - job_name: prometheus
+      static_configs:
+      - targets:
+        - localhost:9090
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-nodes-cadvisor
+      kubernetes_sd_configs:
+      - role: node
+      metric_relabel_configs:
+      - action: keep
+        regex: (container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_errors_total|container_network_transmit_errors_total|container_network_receive_packets_dropped_total|container_network_transmit_packets_dropped_total|container_memory_usage_bytes|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_periods_total|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_periods_total|container_fs_inodes_free|container_fs_inodes_total|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_periods_total|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_fs_inodes_free|container_fs_inodes_total|container_fs_usage_bytes|container_fs_limit_bytes|container_spec_cpu_shares|container_spec_memory_limit_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_fs_reads_bytes_total|container_network_receive_bytes_total|container_fs_writes_bytes_total|container_fs_reads_bytes_total|cadvisor_version_info|kubecost_pv_info)
+        source_labels:
+        - __name__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - container
+        target_label: container_name
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - pod
+        target_label: pod_name
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - replacement: kubernetes.default.svc:443
+        target_label: __address__
+      - regex: (.+)
+        replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+        source_labels:
+        - __meta_kubernetes_node_name
+        target_label: __metrics_path__
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - job_name: kubernetes-service-endpoints
+      kubernetes_sd_configs:
+      - role: endpoints
+      metric_relabel_configs:
+      - action: keep
+        regex: (container_cpu_allocation|container_cpu_usage_seconds_total|container_fs_limit_bytes|container_fs_writes_bytes_total|container_gpu_allocation|container_memory_allocation_bytes|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total|DCGM_FI_DEV_GPU_UTIL|deployment_match_labels|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_ready|kube_deployment_spec_replicas|kube_deployment_status_replicas|kube_deployment_status_replicas_available|kube_job_status_failed|kube_namespace_annotations|kube_namespace_labels|kube_node_info|kube_node_labels|kube_node_status_allocatable|kube_node_status_allocatable_cpu_cores|kube_node_status_allocatable_memory_bytes|kube_node_status_capacity|kube_node_status_capacity_cpu_cores|kube_node_status_capacity_memory_bytes|kube_node_status_condition|kube_persistentvolume_capacity_bytes|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_limits_cpu_cores|kube_pod_container_resource_limits_memory_bytes|kube_pod_container_resource_requests|kube_pod_container_resource_requests_cpu_cores|kube_pod_container_resource_requests_memory_bytes|kube_pod_container_status_restarts_total|kube_pod_container_status_running|kube_pod_container_status_terminated_reason|kube_pod_labels|kube_pod_owner|kube_pod_status_phase|kube_replicaset_owner|kube_statefulset_replicas|kube_statefulset_status_replicas|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|kubecost_pod_network_egress_bytes_total|node_cpu_hourly_cost|node_cpu_seconds_total|node_disk_reads_completed|node_disk_reads_completed_total|node_disk_writes_completed|node_disk_writes_completed_total|node_filesystem_device_error|node_gpu_count|node_gpu_hourly_cost|node_memory_Buffers_bytes|node_memory_Cached_bytes|node_memory_MemAvailable_bytes|node_memory_MemFree_bytes|node_memory_MemTotal_bytes|node_network_transmit_bytes_total|node_ram_hourly_cost|node_total_hourly_cost|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels|kubecost_pv_info|up)
+        source_labels:
+        - __name__
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: kubernetes_namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: kubernetes_name
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: kubernetes_node
+    - job_name: kubernetes-service-endpoints-slow
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: kubernetes_namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: kubernetes_name
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: kubernetes_node
+      scrape_interval: 5m
+      scrape_timeout: 30s
+    - honor_labels: true
+      job_name: prometheus-pushgateway
+      kubernetes_sd_configs:
+      - role: service
+      relabel_configs:
+      - action: keep
+        regex: pushgateway
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_probe
+    - job_name: kubernetes-services
+      kubernetes_sd_configs:
+      - role: service
+      metrics_path: /probe
+      params:
+        module:
+        - http_2xx
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_probe
+      - source_labels:
+        - __address__
+        target_label: __param_target
+      - replacement: blackbox
+        target_label: __address__
+      - source_labels:
+        - __param_target
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels:
+        - __meta_kubernetes_namespace
+        target_label: kubernetes_namespace
+      - source_labels:
+        - __meta_kubernetes_service_name
+        target_label: kubernetes_name
+    - job_name: kubecost
+      honor_labels: true
+      scrape_interval: 1m
+      scrape_timeout: 60s
+      metrics_path: /metrics
+      scheme: http
+      dns_sd_configs:
+      - names:
+        - kubecost-cost-analyzer
+        type: 'A'
+        port: 9003
+    - job_name: kubecost-networking
+      kubernetes_sd_configs:
+        - role: pod
+      relabel_configs:
+      # Scrape only the the targets matching the following metadata
+        - source_labels: [__meta_kubernetes_pod_label_app]
+          action: keep
+          regex:  kubecost-network-costs
+
+  recording_rules.yml: |
+    {}
+  rules: |
+    groups:
+    - name: CPU
+      rules:
+      - expr: sum(rate(container_cpu_usage_seconds_total{container_name!=""}[5m]))
+        record: cluster:cpu_usage:rate5m
+      - expr: rate(container_cpu_usage_seconds_total{container_name!=""}[5m])
+        record: cluster:cpu_usage_nosum:rate5m
+      - expr: avg(irate(container_cpu_usage_seconds_total{container_name!="POD", container_name!=""}[5m]))
+          by (container_name,pod_name,namespace)
+        record: kubecost_container_cpu_usage_irate
+      - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""})
+          by (container_name,pod_name,namespace)
+        record: kubecost_container_memory_working_set_bytes
+      - expr: sum(container_memory_working_set_bytes{container_name!="POD",container_name!=""})
+        record: kubecost_cluster_memory_working_set_bytes
+    - name: Savings
+      rules:
+      - expr: sum(avg(kube_pod_owner{owner_kind!="DaemonSet"}) by (pod) * sum(container_cpu_allocation)
+          by (pod))
+        labels:
+          daemonset: "false"
+        record: kubecost_savings_cpu_allocation
+      - expr: sum(avg(kube_pod_owner{owner_kind="DaemonSet"}) by (pod) * sum(container_cpu_allocation)
+          by (pod)) / sum(kube_node_info)
+        labels:
+          daemonset: "true"
+        record: kubecost_savings_cpu_allocation
+      - expr: sum(avg(kube_pod_owner{owner_kind!="DaemonSet"}) by (pod) * sum(container_memory_allocation_bytes)
+          by (pod))
+        labels:
+          daemonset: "false"
+        record: kubecost_savings_memory_allocation_bytes
+      - expr: sum(avg(kube_pod_owner{owner_kind="DaemonSet"}) by (pod) * sum(container_memory_allocation_bytes)
+          by (pod)) / sum(kube_node_info)
+        labels:
+          daemonset: "true"
+        record: kubecost_savings_memory_allocation_bytes
+---
+# Source: cost-analyzer/templates/cost-analyzer-config-map-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubecost-cost-analyzer
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+data:
+    prometheus-alertmanager-endpoint: http://kubecost-prometheus-alertmanager.kubecost
+    prometheus-server-endpoint: http://kubecost-prometheus-server.kubecost
+    kubecost-token: not-applied
+---
+# Source: cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+data:
+  nginx.conf: |
+    gzip_static  on;
+
+    # Enable gzip encoding for content of the provided types of 50kb and higher.
+    gzip on;
+    gzip_min_length 50000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types
+        application/atom+xml
+        application/geo+json
+        application/javascript
+        application/x-javascript
+        application/json
+        application/ld+json
+        application/manifest+json
+        application/rdf+xml
+        application/rss+xml
+        application/vnd.ms-fontobject
+        application/wasm
+        application/x-web-app-manifest+json
+        application/xhtml+xml
+        application/xml
+        font/eot
+        font/otf
+        font/ttf
+        image/bmp
+        image/svg+xml
+        text/cache-manifest
+        text/calendar
+        text/css
+        text/javascript
+        text/markdown
+        text/plain
+        text/xml
+        text/x-component
+        text/x-cross-domain-policy;
+
+    upstream api {
+        server kubecost-cost-analyzer.kubecost:9001;
+    }
+
+    upstream model {
+        server kubecost-cost-analyzer.kubecost:9003;
+    }
+    upstream grafana {
+        server kubecost-grafana.kubecost;
+    }
+
+    server {
+        server_name _;
+        root /var/www;
+        index index.html;
+        large_client_header_buffers 4 32k;
+        add_header Cache-Control "must-revalidate";
+
+        error_page 504 /custom_504.html;
+        location = /custom_504.html {
+            internal;
+        }
+        add_header Cache-Control "max-age=300";
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+        add_header ETag "1.97.0";
+        listen 9090;
+        listen [::]:9090;
+        location /api/ {
+            proxy_pass http://api/;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location /model/ {
+            proxy_connect_timeout       180;
+            proxy_send_timeout          180;
+            proxy_read_timeout          180;
+            proxy_pass http://model/;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location ~ ^/(turndown|cluster)/ {
+
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            return 404;
+        }
+        location /oidc/ {
+            proxy_connect_timeout       180;
+            proxy_send_timeout          180;
+            proxy_read_timeout          180;
+            proxy_pass http://model/oidc/;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location /saml/ {
+            proxy_connect_timeout       180;
+            proxy_send_timeout          180;
+            proxy_read_timeout          180;
+            proxy_pass http://model/saml/;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location /login {
+            proxy_connect_timeout       180;
+            proxy_send_timeout          180;
+            proxy_read_timeout          180;
+            proxy_pass http://model/login;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /logout {
+            proxy_connect_timeout       180;
+            proxy_send_timeout          180;
+            proxy_read_timeout          180;
+            proxy_pass http://model/logout;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        location /grafana/ {
+            proxy_pass http://grafana/;
+            proxy_redirect off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header  X-Real-IP  $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+        }
+
+    }
+---
+# Source: cost-analyzer/templates/grafana-attached-disk-metrics-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: attached-disk-metrics-dashboard
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+    grafana_dashboard: "1"
+  annotations:
+    {}
+data:
+    attached-disks.json: |-
+        {
+          "annotations": {
+            "list": [
+              {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+              }
+            ]
+          },
+          "editable": true,
+          "gnetId": null,
+          "graphTooltip": 0,
+          "id": 10,
+          "iteration": 1589748792557,
+          "links": [],
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 0
+              },
+              "id": 2,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(container_fs_limit_bytes{instance=~'$disk', device!=\"tmpfs\", id=\"/\"}) by (instance)",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Disk Size",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "decbytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 0
+              },
+              "id": 4,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(container_fs_usage_bytes{instance=~'$disk',id=\"/\"}) by (instance) / sum(container_fs_limit_bytes{instance=~'$disk',device!=\"tmpfs\", id=\"/\"}) by (instance)",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Disk Utilization",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 1,
+                  "format": "percentunit",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 9
+              },
+              "id": 5,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "1 - sum(container_fs_inodes_free{instance=~'$disk',id=\"/\"}) by (instance) / sum(container_fs_inodes_total{instance=~'$disk',id=\"/\"}) by (instance)",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "iNode Utilization",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 1,
+                  "format": "percentunit",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 9
+              },
+              "id": 3,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(container_fs_usage_bytes{instance=~'$disk',id=\"/\"}) by (instance)",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Disk Usage",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "decbytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            }
+          ],
+          "schemaVersion": 16,
+          "style": "dark",
+          "tags": [
+            "cost",
+            "utilization",
+            "metrics"
+          ],
+          "templating": {
+            "list": [
+              {
+                "allValue": null,
+                "current": {
+                  "text": "All",
+                  "value": "$__all"
+                },
+                "datasource": "${datasource}",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "disk",
+                "options": [],
+                "query": "query_result(sum(container_fs_limit_bytes{device!=\"tmpfs\", id=\"/\"}) by (instance))",
+                "refresh": 1,
+                "regex": "/instance=\\\"(.*?)(\\\")/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "current": {
+                  "selected": true,
+                  "text": "default-kubecost",
+                  "value": "default-kubecost"
+                },
+                "error": null,
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+              }
+            ]
+          },
+          "time": {
+            "from": "now-7d",
+            "to": "now"
+          },
+          "timepicker": {
+            "refresh_intervals": [
+              "5s",
+              "10s",
+              "30s",
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "2h",
+              "1d"
+            ],
+            "time_options": [
+              "5m",
+              "15m",
+              "1h",
+              "6h",
+              "12h",
+              "24h",
+              "2d",
+              "7d",
+              "30d"
+            ]
+          },
+          "timezone": "",
+          "title": "Attached disk metrics",
+          "uid": "nBH7qBgMk",
+          "version": 2
+        }
+---
+# Source: cost-analyzer/templates/grafana-dashboard-cluster-metrics-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-metrics-dashboard
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+    grafana_dashboard: "1"
+  annotations:
+    {}
+data:
+    cluster-metrics.json: |-
+        {
+          "annotations": {
+            "list": [
+              {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+              }
+            ]
+          },
+          "description": "Cost metrics from the Kubecost product",
+          "editable": true,
+          "gnetId": null,
+          "graphTooltip": 0,
+          "id": 7,
+          "iteration": 1558062099204,
+          "links": [],
+          "panels": [
+            {
+              "content": "Note: this dashboard requires Kubecost metrics to be available in your Prometheus deployment. [Learn more](https://github.com/kubecost/cost-model/blob/master/PROMETHEUS.md)",
+              "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 0
+              },
+              "id": 27,
+              "links": [],
+              "mode": "markdown",
+              "title": "",
+              "transparent": true,
+              "type": "text"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "description": "Monthly run rate of CPU + GPU costs based on currently provisioned resources.",
+              "format": "currencyUSD",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 6,
+                "x": 0,
+                "y": 2
+              },
+              "hideTimeOverride": true,
+              "id": 2,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": true,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum(\n  avg(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node) * avg(node_cpu_hourly_cost) by (node) * 730 * (1-$useDiscount/100) +\n  avg(node_gpu_hourly_cost) by (node) * 730 * (1-$useDiscount/100)\n)",
+                  "format": "time_series",
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " {{ node }}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": "",
+              "timeFrom": "15m",
+              "timeShift": null,
+              "title": "CPU Cost",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "description": "Monthly run rate of memory costs based on currently provisioned expenses.",
+              "format": "currencyUSD",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 6,
+                "x": 6,
+                "y": 2
+              },
+              "hideTimeOverride": true,
+              "id": 3,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum(\n  avg(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node) / 1024 / 1024 / 1024 * avg(node_ram_hourly_cost) by (node) * 730 * (1-$useDiscount/100)\n)",
+                  "format": "time_series",
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " {{ node }}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": "",
+              "timeFrom": "15m",
+              "timeShift": null,
+              "title": "Memory Cost",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "description": "Monthly run rate of attached storage and PV costs based on currently provisioned resources.",
+              "format": "currencyUSD",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 6,
+                "x": 12,
+                "y": 2
+              },
+              "hideTimeOverride": true,
+              "id": 4,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum(avg(pv_hourly_cost) by (persistentvolume) * 730 * avg(kube_persistentvolume_capacity_bytes) by (persistentvolume) / 1024 / 1024 / 1024) \n+\nsum(sum(container_fs_limit_bytes{device!=\"tmpfs\", id=\"/\"}) by (instance) / 1024 / 1024 / 1024) * $localStorageGBCost",
+                  "format": "time_series",
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " {{ node }}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": "",
+              "timeFrom": "15m",
+              "timeShift": null,
+              "title": "Storage Cost",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "description": "Sum of compute, memory, storage and network costs.",
+              "format": "currencyUSD",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 18,
+                "y": 2
+              },
+              "hideTimeOverride": true,
+              "id": 11,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "# Compute\nsum(\n  avg(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node) * avg(node_cpu_hourly_cost) by (node) * 730 * (1-$useDiscount/100) +\n  avg(node_gpu_hourly_cost) by (node) * 730 * (1-$useDiscount/100)\n) +\n\n\n# Memory\nsum(\n  avg(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node) / 1024 / 1024 / 1024 * avg(node_ram_hourly_cost) by (node) * 730 * (1-$useDiscount/100)\n) +\n\n# Storage \n\nsum(avg(pv_hourly_cost) by (persistentvolume) * 730 * avg(kube_persistentvolume_capacity_bytes) by (persistentvolume) / 1024 / 1024 / 1024) \n+\nsum(sum(container_fs_limit_bytes{device!=\"tmpfs\", id=\"/\"}) by (instance) / 1024 / 1024 / 1024) * $localStorageGBCost",
+                  "format": "time_series",
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " {{ node }}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": "",
+              "timeFrom": "15m",
+              "timeShift": null,
+              "title": "Total Cost",
+              "type": "singlestat",
+              "valueFontSize": "120%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": true,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(50, 172, 45, 0.97)",
+                "#c15c17"
+              ],
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "description": "Current CPU use from applications divided by allocatable CPUs",
+              "editable": true,
+              "error": false,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": true,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 0,
+                "y": 5
+              },
+              "height": "180px",
+              "hideTimeOverride": true,
+              "id": 13,
+              "interval": null,
+              "isNew": true,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "(\n sum(\n   count(irate(container_cpu_usage_seconds_total{id=\"/\"}[10m])) by (instance)\n   * on (instance) \n   sum(irate(container_cpu_usage_seconds_total{id=\"/\"}[10m])) by (instance)\n ) \n / \n (sum (kube_node_status_allocatable{resource=\"cpu\", unit=\"core\"}))\n) * 100",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "30, 80",
+              "timeFrom": "",
+              "title": "CPU Utilization",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": true,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(50, 172, 45, 0.97)",
+                "#c15c17"
+              ],
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "description": "Current CPU reservation requests from applications vs allocatable CPU",
+              "editable": true,
+              "error": false,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": true,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 3,
+                "y": 5
+              },
+              "height": "180px",
+              "id": 15,
+              "interval": null,
+              "isNew": true,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "SUM(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"}) / SUM(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\"}) * 100",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "30, 80",
+              "title": "CPU Requests",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": true,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(50, 172, 45, 0.97)",
+                "#c15c17"
+              ],
+              "datasource": "${datasource}",
+              "description": "Current RAM use vs RAM available",
+              "editable": true,
+              "error": false,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": true,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 6,
+                "y": 5
+              },
+              "height": "180px",
+              "hideTimeOverride": true,
+              "id": 17,
+              "interval": null,
+              "isNew": true,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "SUM(container_memory_usage_bytes{namespace!=\"\"}) / SUM(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"}) * 100",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "refId": "B"
+                }
+              ],
+              "thresholds": "30,80",
+              "timeFrom": "",
+              "title": "RAM Utilization",
+              "transparent": false,
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": true,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(50, 172, 45, 0.97)",
+                "#c15c17"
+              ],
+              "datasource": "${datasource}",
+              "description": "Current RAM requests vs RAM available",
+              "editable": true,
+              "error": false,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": true,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 9,
+                "y": 5
+              },
+              "height": "180px",
+              "id": 19,
+              "interval": null,
+              "isNew": true,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\"})\n /\n sum(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"})\n) * 100",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "30,80",
+              "title": "RAM Requests",
+              "transparent": false,
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": true,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(50, 172, 45, 0.97)",
+                "#c15c17"
+              ],
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "description": "This gauge shows the current standard storage use, including cluster storage, vs storage available",
+              "editable": true,
+              "error": false,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": true,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 12,
+                "y": 5
+              },
+              "height": "180px",
+              "hideTimeOverride": true,
+              "id": 21,
+              "interval": null,
+              "isNew": true,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum (\n sum(kube_persistentvolumeclaim_info) by (persistentvolumeclaim, namespace)\n + on (persistentvolumeclaim, namespace)\n sum(pod_pvc_allocation) by (persistentvolumeclaim, namespace) or up * 0\n + sum(container_fs_usage_bytes{device=~\"^/dev/[sv]d[a-z][1-9]$\",id=\"/\"})\n) /\nsum (\n sum(kube_persistentvolumeclaim_info) by (persistentvolumeclaim, namespace)\n + on (persistentvolumeclaim, namespace)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n + sum(container_fs_limit_bytes{device=~\"^/dev/[sv]d[a-z][1-9]$\",id=\"/\"})\n) * 100",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": "30, 80",
+              "timeFrom": "",
+              "title": "Storage Utilization",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "description": "Monthly run rate of CPU + GPU costs",
+              "fill": 1,
+              "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 0,
+                "y": 9
+              },
+              "id": 6,
+              "interval": "1m",
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(\n  avg(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node) * avg(node_cpu_hourly_cost) by (node) * 730 +\n  avg(node_gpu_hourly_cost) by (node) * 730\n)",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "compute cost",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Compute Cost",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "currencyUSD",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "description": "Monthly run rate of memory costs",
+              "fill": 1,
+              "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 6,
+                "y": 9
+              },
+              "id": 9,
+              "interval": "1m",
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(\n  avg(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node) / 1024 / 1024 / 1024 * avg(node_ram_hourly_cost) by (node) * 730\n)",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "memory cost",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Memory Cost",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "currencyUSD",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "description": "Monthly run rate of attached disk + PV storage costs",
+              "fill": 1,
+              "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 12,
+                "y": 9
+              },
+              "id": 10,
+              "interval": "1m",
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(\n  avg(avg_over_time(pv_hourly_cost[$timeRange] offset 1m)) by (persistentvolume) * 730 \n  * avg(avg_over_time(kube_persistentvolume_capacity_bytes[$timeRange] offset 1m)) by (persistentvolume) / 1024 / 1024 / 1024\n) +\nsum(avg(container_fs_limit_bytes{device!=\"tmpfs\", id=\"/\"}) by (instance) / 1024 / 1024 / 1024) * $localStorageGBCost",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "storage cost",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Storage Cost",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "currencyUSD",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "description": "Sum of compute, memory, and storage costs",
+              "fill": 1,
+              "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 18,
+                "y": 9
+              },
+              "id": 22,
+              "interval": "1m",
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "# Compute\nsum(\n  avg(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node) * avg(node_cpu_hourly_cost) by (node) * 730 * (1-$useDiscount/100) +\n  avg(node_gpu_hourly_cost) by (node) * 730 * (1-$useDiscount/100)\n) +\n\n\n# Memory\nsum(\n  avg(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node) / 1024 / 1024 / 1024 * avg(node_ram_hourly_cost) by (node) * 730 * (1-$useDiscount/100)\n) +\n\n# Storage \n\nsum(avg(pv_hourly_cost) by (persistentvolume) * 730 * avg(kube_persistentvolume_capacity_bytes) by (persistentvolume) / 1024 / 1024 / 1024) \n+\nsum(sum(container_fs_limit_bytes{device!=\"tmpfs\", id=\"/\"}) by (instance) / 1024 / 1024 / 1024) * $localStorageGBCost",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "total cost",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Total Cost",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "currencyUSD",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "columns": [],
+              "datasource": "${datasource}",
+              "description": "Cost of by resource class of currently provisioned nodes",
+              "fontSize": "100%",
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 16
+              },
+              "id": 8,
+              "links": [],
+              "pageSize": null,
+              "scroll": true,
+              "showHeader": true,
+              "sort": {
+                "col": 4,
+                "desc": false
+              },
+              "styles": [
+                {
+                  "alias": "",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Time",
+                  "thresholds": [],
+                  "type": "hidden",
+                  "unit": "short"
+                },
+                {
+                  "alias": "Compute Cost",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "short"
+                },
+                {
+                  "alias": "CPU Cost",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value #A",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "currencyUSD"
+                },
+                {
+                  "alias": "Mem Cost",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value #B",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "currencyUSD"
+                },
+                {
+                  "alias": "Total",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value #C",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "currencyUSD"
+                },
+                {
+                  "alias": "",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "instance",
+                  "thresholds": [],
+                  "type": "hidden",
+                  "unit": "short"
+                },
+                {
+                  "alias": "GPU",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value #D",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "short"
+                },
+                {
+                  "alias": "",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "decimals": 2,
+                  "pattern": "/.*/",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "short"
+                }
+              ],
+              "targets": [
+                {
+                  "expr": "avg(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node) * avg(node_cpu_hourly_cost or up * 0) by (node) * 730 * (1-$useDiscount/100)",
+                  "format": "table",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "legendFormat": "",
+                  "refId": "A"
+                },
+                {
+                  "expr": "avg(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node) / 1024 / 1024 / 1024 * avg(node_ram_hourly_cost) by (node) * 730 * (1-$useDiscount/100)",
+                  "format": "table",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "legendFormat": "",
+                  "refId": "B"
+                },
+                {
+                  "expr": "avg(node_gpu_hourly_cost) by (node) * 730 * (1-$useDiscount/100)",
+                  "format": "table",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "refId": "D"
+                },
+                {
+                  "expr": "# CPU  \navg(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node) * avg(node_cpu_hourly_cost or up * 0) by (node) * 730 * (1-$useDiscount/100) +\n# GPU\navg(node_gpu_hourly_cost) by (node) * 730 * (1-$useDiscount/100) +\n# Memory\navg(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node) / 1024 / 1024 / 1024 * avg(node_ram_hourly_cost) by (node) * 730 * (1-$useDiscount/100)\n",
+                  "format": "table",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "refId": "C"
+                }
+              ],
+              "title": "Cost by node",
+              "transform": "table",
+              "type": "table"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "description": "Monthly run rate of attached disk + PV storage costs based on currently provisioned resources.",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 16
+              },
+              "id": 25,
+              "interval": "1m",
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "connected",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": true,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(\n  avg(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node) * avg(node_cpu_hourly_cost) by (node) * 730 +\n  avg(node_gpu_hourly_cost) by (node) * 730\n)",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "cpu",
+                  "refId": "B"
+                },
+                {
+                  "expr": "sum(\n  avg(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node) / 1024 / 1024 / 1024 * avg(node_ram_hourly_cost) by (node) * 730\n)",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "memory",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(\n  avg(avg_over_time(pv_hourly_cost[$timeRange] offset 1m)) by (persistentvolume) * 730 \n  * avg(avg_over_time(kube_persistentvolume_capacity_bytes[$timeRange] offset 1m)) by (persistentvolume) / 1024 / 1024 / 1024\n) +\nsum(avg(container_fs_limit_bytes{device!=\"tmpfs\", id=\"/\"}) by (instance) / 1024 / 1024 / 1024) * $localStorageGBCost",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "storage",
+                  "refId": "C"
+                },
+                {
+                  "expr": "SUM(rate(node_network_transmit_bytes_total{device=\"eth0\"}[60m]) / 1024 / 1024 / 1024 ) * (60 * 60 * 24 * 30) * $percentEgress * $egressCost ",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "network",
+                  "refId": "D"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Cost by Resource",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "currencyUSD",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            }
+          ],
+          "refresh": false,
+          "schemaVersion": 16,
+          "style": "dark",
+          "tags": [
+            "cost",
+            "utilization",
+            "metrics"
+          ],
+          "templating": {
+            "list": [
+              {
+                "auto": true,
+                "auto_count": 1,
+                "auto_min": "1m",
+                "current": {
+                  "text": "auto",
+                  "value": "$__auto_interval_timeRange"
+                },
+                "hide": 2,
+                "label": null,
+                "name": "timeRange",
+                "options": [
+                  {
+                    "selected": true,
+                    "text": "auto",
+                    "value": "$__auto_interval_timeRange"
+                  },
+                  {
+                    "selected": false,
+                    "text": "1h",
+                    "value": "1h"
+                  },
+                  {
+                    "selected": false,
+                    "text": "6h",
+                    "value": "6h"
+                  },
+                  {
+                    "selected": false,
+                    "text": "12h",
+                    "value": "12h"
+                  },
+                  {
+                    "selected": false,
+                    "text": "1d",
+                    "value": "1d"
+                  },
+                  {
+                    "selected": false,
+                    "text": "7d",
+                    "value": "7d"
+                  },
+                  {
+                    "selected": false,
+                    "text": "14d",
+                    "value": "14d"
+                  },
+                  {
+                    "selected": false,
+                    "text": "30d",
+                    "value": "30d"
+                  },
+                  {
+                    "selected": false,
+                    "text": "90d",
+                    "value": "90d"
+                  }
+                ],
+                "query": "1h,6h,12h,1d,7d,14d,30d,90d",
+                "refresh": 2,
+                "skipUrlSync": false,
+                "type": "interval"
+              },
+              {
+                "current": {
+                  "text": ".04",
+                  "value": ".04"
+                },
+                "hide": 2,
+                "label": "Cost per Gb hour for attached disks",
+                "name": "localStorageGBCost",
+                "options": [
+                  {
+                    "selected": true,
+                    "text": ".04",
+                    "value": ".04"
+                  }
+                ],
+                "query": ".04",
+                "skipUrlSync": false,
+                "type": "constant"
+              },
+              {
+                "current": {
+                  "tags": [],
+                  "text": "0",
+                  "value": "0"
+                },
+                "hide": 0,
+                "label": "Sustained Use Discount %",
+                "name": "useDiscount",
+                "options": [
+                  {
+                    "selected": true,
+                    "text": "0",
+                    "value": "0"
+                  }
+                ],
+                "query": "0",
+                "skipUrlSync": false,
+                "type": "constant"
+              },
+              {
+                "current": {
+                  "text": ".1",
+                  "value": ".1"
+                },
+                "hide": 2,
+                "label": null,
+                "name": "percentEgress",
+                "options": [
+                  {
+                    "selected": true,
+                    "text": ".1",
+                    "value": ".1"
+                  }
+                ],
+                "query": ".1",
+                "skipUrlSync": false,
+                "type": "constant"
+              },
+              {
+                "current": {
+                  "text": ".12",
+                  "value": ".12"
+                },
+                "hide": 2,
+                "label": null,
+                "name": "egressCost",
+                "options": [
+                  {
+                    "selected": true,
+                    "text": ".12",
+                    "value": ".12"
+                  }
+                ],
+                "query": ".12",
+                "skipUrlSync": false,
+                "type": "constant"
+              },
+              {
+                "current": {
+                  "selected": true,
+                  "text": "default-kubecost",
+                  "value": "default-kubecost"
+                },
+                "error": null,
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+              }
+            ]
+          },
+          "time": {
+            "from": "now-7d",
+            "to": "now"
+          },
+          "timepicker": {
+            "refresh_intervals": [
+              "5s",
+              "10s",
+              "30s",
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "2h",
+              "1d"
+            ],
+            "time_options": [
+              "5m",
+              "15m",
+              "1h",
+              "6h",
+              "12h",
+              "24h",
+              "2d",
+              "7d",
+              "30d"
+            ]
+          },
+          "timezone": "",
+          "title": "Kubecost cluster metrics",
+          "uid": "JOUdHGZZz",
+          "version": 20
+        }
+---
+# Source: cost-analyzer/templates/grafana-dashboard-cluster-utilization-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-utilization-dashboard
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+    grafana_dashboard: "1"
+  annotations:
+    {}
+data:
+    cluster-utilization.json: |-
+        {
+            "annotations": {
+              "list": [
+                {
+                  "builtIn": 1,
+                  "datasource": "-- Grafana --",
+                  "enable": true,
+                  "hide": true,
+                  "iconColor": "rgba(0, 211, 255, 1)",
+                  "name": "Annotations & Alerts",
+                  "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                  },
+                  "type": "dashboard"
+                }
+              ]
+            },
+            "description": "A dashboard to help manage Kubernetes cluster costs and resources",
+            "editable": true,
+            "fiscalYearStartMonth": 0,
+            "gnetId": 6873,
+            "graphTooltip": 0,
+            "id": 10,
+            "iteration": 1645112913364,
+            "links": [],
+            "liveNow": false,
+            "panels": [
+              {
+                "gridPos": {
+                  "h": 2,
+                  "w": 24,
+                  "x": 0,
+                  "y": 0
+                },
+                "id": 86,
+                "links": [],
+                "options": {
+                  "content": "This dashboard shows monthly cost estimates for the cluster, based on **current** CPU, RAM and storage provisioned.",
+                  "mode": "markdown"
+                },
+                "pluginVersion": "8.3.2",
+                "transparent": true,
+                "type": "text"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "decimals": 2,
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "currencyUSD"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 6,
+                  "x": 0,
+                  "y": 2
+                },
+                "hideTimeOverride": true,
+                "id": 75,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "textMode": "auto"
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "P0C970EB638C812D0"
+                    },
+                    "exemplar": false,
+                    "expr": "sum(\n (\n (\n sum(kube_node_status_capacity_cpu_cores) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible=\"true\"}) by (node)\n ) * $costpcpu\n )\n or\n (\n (\n sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible!=\"true\"}) by (node)\n ) * ($costcpu - ($costcpu / 100 * $costDiscount))\n )\n) ",
+                    "format": "time_series",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": " {{ node }}",
+                    "refId": "A"
+                  }
+                ],
+                "timeFrom": "15m",
+                "title": "CPU Cost",
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "decimals": 2,
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "currencyUSD"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 6,
+                  "x": 6,
+                  "y": 2
+                },
+                "hideTimeOverride": true,
+                "id": 77,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "textMode": "auto"
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "P0C970EB638C812D0"
+                    },
+                    "exemplar": false,
+                    "expr": "sum(\n (\n (\n sum(kube_node_status_capacity_memory_bytes) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible=\"true\"}) by (node)\n ) /1024/1024/1024 * $costpram\n )\n or\n (\n (\n sum(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible!=\"true\"}) by (node)\n ) /1024/1024/1024 * ($costram - ($costram / 100 * $costDiscount))\n)\n) ",
+                    "format": "time_series",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": " {{ node }}",
+                    "refId": "A"
+                  }
+                ],
+                "timeFrom": "15m",
+                "title": "RAM Cost",
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "decimals": 2,
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "currencyUSD"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 6,
+                  "x": 12,
+                  "y": 2
+                },
+                "hideTimeOverride": true,
+                "id": 78,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "textMode": "auto"
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "P0C970EB638C812D0"
+                    },
+                    "exemplar": false,
+                    "expr": "sum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n) / 1024 / 1024 /1024 * $costStorageSSD\n\n+\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n) / 1024 / 1024 /1024 * $costStorageStandard\n\n+ \n\nsum(container_fs_limit_bytes{id=\"/\"}) / 1024 / 1024 / 1024 * 1.03 * $costStorageStandard",
+                    "format": "time_series",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": " {{ node }}",
+                    "refId": "A"
+                  }
+                ],
+                "timeFrom": "15m",
+                "title": "Storage Cost (Cluster and PVC)",
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "description": "Represents a near worst-case approximation of network costs.",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "decimals": 2,
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "currencyUSD"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 6,
+                  "x": 18,
+                  "y": 2
+                },
+                "hideTimeOverride": true,
+                "id": 129,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "textMode": "auto"
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "P0C970EB638C812D0"
+                    },
+                    "exemplar": false,
+                    "expr": "SUM(rate(node_network_transmit_bytes_total{device=\"eth0\"}[60m]) / 1024 / 1024 / 1024 ) * (60 * 60 * 24 * 30) * $costEgress",
+                    "format": "time_series",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": " {{ node }}",
+                    "refId": "A"
+                  }
+                ],
+                "timeFrom": "15m",
+                "title": "Network Egress Cost",
+                "type": "stat"
+              },
+              {
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "Current CPU use from applications divided by allocatable CPUs",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "decimals": 2,
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "rgba(245, 54, 54, 0.9)",
+                          "value": null
+                        },
+                        {
+                          "color": "rgba(50, 172, 45, 0.97)",
+                          "value": 30
+                        },
+                        {
+                          "color": "#c15c17",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "percent"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 0,
+                  "y": 6
+                },
+                "hideTimeOverride": true,
+                "id": 82,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "expr": "(\n sum(\n count(irate(container_cpu_usage_seconds_total{id=\"/\"}[10m])) by (instance)\n * on (instance) \n sum(irate(container_cpu_usage_seconds_total{id=\"/\"}[10m])) by (instance)\n ) \n / \n (sum (kube_node_status_allocatable{resource=\"cpu\", unit=\"core\"}))\n) * 100",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "refId": "A",
+                    "step": 10
+                  }
+                ],
+                "timeFrom": "",
+                "title": "CPU Utilization",
+                "type": "gauge"
+              },
+              {
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "Current CPU reservation requests from applications vs allocatable CPU",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "decimals": 2,
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "rgba(245, 54, 54, 0.9)",
+                          "value": null
+                        },
+                        {
+                          "color": "rgba(50, 172, 45, 0.97)",
+                          "value": 30
+                        },
+                        {
+                          "color": "#c15c17",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "percent"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 3,
+                  "y": 6
+                },
+                "id": 91,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "expr": "SUM(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"}) / SUM(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\"}) * 100",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "refId": "A",
+                    "step": 10
+                  }
+                ],
+                "title": "CPU Requests",
+                "type": "gauge"
+              },
+              {
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "Current RAM use vs RAM available",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "rgba(245, 54, 54, 0.9)",
+                          "value": null
+                        },
+                        {
+                          "color": "rgba(50, 172, 45, 0.97)",
+                          "value": 30
+                        },
+                        {
+                          "color": "#c15c17",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "percent"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 6,
+                  "y": 6
+                },
+                "hideTimeOverride": true,
+                "id": 80,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "expr": "SUM(container_memory_usage_bytes{namespace!=\"\"}) / SUM(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"}) * 100",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "expr": "",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "refId": "B"
+                  }
+                ],
+                "timeFrom": "",
+                "title": "RAM Utilization",
+                "type": "gauge"
+              },
+              {
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "Current RAM requests vs RAM available",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "rgba(245, 54, 54, 0.9)",
+                          "value": null
+                        },
+                        {
+                          "color": "rgba(50, 172, 45, 0.97)",
+                          "value": 30
+                        },
+                        {
+                          "color": "#c15c17",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "percent"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 9,
+                  "y": 6
+                },
+                "id": 92,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "expr": "(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\"})\n /\n sum(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"})\n) * 100",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "refId": "A",
+                    "step": 10
+                  }
+                ],
+                "title": "RAM Requests",
+                "type": "gauge"
+              },
+              {
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "This gauge shows the current standard storage use, including cluster storage, vs storage available",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "decimals": 2,
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "rgba(245, 54, 54, 0.9)",
+                          "value": null
+                        },
+                        {
+                          "color": "rgba(50, 172, 45, 0.97)",
+                          "value": 30
+                        },
+                        {
+                          "color": "#c15c17",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "percent"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 12,
+                  "y": 6
+                },
+                "hideTimeOverride": true,
+                "id": 95,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "expr": "sum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kubelet_volume_stats_used_bytes) by (persistentvolumeclaim, namespace) or up * 0\n + sum(container_fs_usage_bytes{device=~\"^/dev/[sv]d[a-z][1-9]$\",id=\"/\"})\n) /\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n + sum(container_fs_limit_bytes{device=~\"^/dev/[sv]d[a-z][1-9]$\",id=\"/\"})\n) * 100",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "refId": "A",
+                    "step": 10
+                  }
+                ],
+                "timeFrom": "",
+                "title": "Storage Utilization",
+                "type": "gauge"
+              },
+              {
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "This gauge shows the current SSD use vs SSD available",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "decimals": 2,
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "rgba(245, 54, 54, 0.9)",
+                          "value": null
+                        },
+                        {
+                          "color": "rgba(50, 172, 45, 0.97)",
+                          "value": 30
+                        },
+                        {
+                          "color": "#c15c17",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "percent"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 3,
+                  "x": 15,
+                  "y": 6
+                },
+                "hideTimeOverride": true,
+                "id": 96,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "expr": "sum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kubelet_volume_stats_used_bytes) by (persistentvolumeclaim, namespace)\n) /\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace)\n) * 100",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "refId": "A",
+                    "step": 10
+                  }
+                ],
+                "timeFrom": "",
+                "title": "SSD Utilization",
+                "type": "gauge"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "description": "Expected monthly cost given current CPU, memory storage, and network resource consumption",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "decimals": 2,
+                    "mappings": [
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "currencyUSD"
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 4,
+                  "w": 6,
+                  "x": 18,
+                  "y": 6
+                },
+                "hideTimeOverride": true,
+                "id": 93,
+                "links": [],
+                "maxDataPoints": 100,
+                "options": {
+                  "colorMode": "none",
+                  "graphMode": "none",
+                  "justifyMode": "auto",
+                  "orientation": "horizontal",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "textMode": "auto"
+                },
+                "pluginVersion": "8.3.2",
+                "targets": [
+                  {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "P0C970EB638C812D0"
+                    },
+                    "exemplar": false,
+                    "expr": "# CPU\nsum(\n (\n (\n sum(kube_node_status_capacity_cpu_cores) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible=\"true\"}) by (node)\n ) * $costpcpu\n )\n or\n (\n (\n sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible!=\"true\"}) by (node)\n ) * ($costcpu - ($costcpu / 100 * $costDiscount))\n )\n) \n\n+ \n\n# Storage\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n) / 1024 / 1024 /1024 * $costStorageSSD\n\n+\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n) / 1024 / 1024 /1024 * $costStorageStandard\n\n+ \n\nsum(container_fs_limit_bytes{id=\"/\"}) / 1024 / 1024 / 1024 * 1.03 * $costStorageStandard \n\n+\n\n# END STORAGE\n# RAM \nsum(\n (\n (\n sum(kube_node_status_capacity_memory_bytes) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible=\"true\"}) by (node)\n ) /1024/1024/1024 * $costpram\n )\n or\n (\n (\n sum(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible!=\"true\"}) by (node)\n ) /1024/1024/1024 * ($costram - ($costram / 100 * $costDiscount))\n)\n)\n\n+\n\n#Network \nSUM(rate(node_network_transmit_bytes_total{device=\"eth0\"}[60m]) / 1024 / 1024 / 1024 ) * (60 * 60 * 24 * 30) * $costEgress",
+                    "format": "time_series",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": " {{ node }}",
+                    "refId": "A"
+                  }
+                ],
+                "timeFrom": "15m",
+                "title": "Total Monthly Cost",
+                "type": "stat"
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "Expected monthly CPU, memory and storage costs given provisioned resources",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 10
+                },
+                "hiddenSeries": false,
+                "id": 120,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": false,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "8.3.2",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "# CPU\nsum(\n (\n (\n sum(kube_node_status_capacity_cpu_cores) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible=\"true\"}) by (node)\n ) * $costpcpu\n )\n or\n (\n (\n sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible!=\"true\"}) by (node)\n ) * ($costcpu - ($costcpu / 100 * $costDiscount))\n )\n) \n\n+ \n\n# Storage\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n) / 1024 / 1024 /1024 * $costStorageSSD\n\n+\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) or up * 0\n) / 1024 / 1024 /1024 * $costStorageStandard\n\n+ \n\nsum(container_fs_limit_bytes{id=\"/\"}) / 1024 / 1024 / 1024 * 1.03 * $costStorageStandard \n\n+\n\n# END STORAGE\n# RAM \nsum(\n (\n (\n sum(kube_node_status_capacity_memory_bytes) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible=\"true\"}) by (node)\n ) /1024/1024/1024 * $costpram\n )\n or\n (\n (\n sum(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node)\n * on (node) group_left (label_cloud_google_com_gke_preemptible)\n avg(kube_node_labels{label_cloud_google_com_gke_preemptible!=\"true\"}) by (node)\n ) /1024/1024/1024 * ($costram - ($costram / 100 * $costDiscount))\n)\n) \n\n+\n\n#Network \nSUM(rate(node_network_transmit_bytes_total{device=\"eth0\"}[60m]) / 1024 / 1024 / 1024 ) * (60 * 60 * 24 * 30) * $costEgress",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "cluster cost",
+                    "refId": "A"
+                  }
+                ],
+                "thresholds": [],
+                "timeRegions": [],
+                "title": "Total monthly cost",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "currencyUSD",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "text": "Avg",
+                    "value": "avg"
+                  }
+                ],
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "Resources allocated to namespace based on container requests",
+                "fontSize": "100%",
+                "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 10
+                },
+                "hideTimeOverride": false,
+                "id": 73,
+                "links": [],
+                "pageSize": 10,
+                "repeatDirection": "v",
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 7,
+                  "desc": true
+                },
+                "styles": [
+                  {
+                    "alias": "Namespace",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(50, 172, 45, 0.97)",
+                      "#c15c17"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "View namespace cost metrics",
+                    "linkUrl": "d/at-cost-analysis-namespace2/namespace-cost-metrics?&var-namespace=$__cell",
+                    "pattern": "namespace",
+                    "thresholds": [
+                      "30",
+                      "80"
+                    ],
+                    "type": "string",
+                    "unit": "currencyUSD"
+                  },
+                  {
+                    "alias": "RAM",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "pattern": "Value #B",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "currencyUSD"
+                  },
+                  {
+                    "alias": "CPU",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #A",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "currencyUSD"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Time",
+                    "thresholds": [],
+                    "type": "hidden",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "PV Storage",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #C",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "currencyUSD"
+                  },
+                  {
+                    "alias": "Total",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #D",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "currencyUSD"
+                  },
+                  {
+                    "alias": "CPU Utilization",
+                    "align": "auto",
+                    "colorMode": "value",
+                    "colors": [
+                      "#bf1b00",
+                      "rgba(50, 172, 45, 0.97)",
+                      "#ef843c"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #E",
+                    "thresholds": [
+                      "30",
+                      "80"
+                    ],
+                    "type": "number",
+                    "unit": "percent"
+                  },
+                  {
+                    "alias": "RAM Utilization",
+                    "align": "auto",
+                    "colorMode": "value",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(50, 172, 45, 0.97)",
+                      "#ef843c"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #F",
+                    "thresholds": [
+                      "30",
+                      "80"
+                    ],
+                    "type": "number",
+                    "unit": "percent"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "(\n sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"}*($costcpu - ($costcpu / 100 * $costDiscount))) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"}*$costpcpu) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ namespace }}",
+                    "refId": "A"
+                  },
+                  {
+                    "expr": "(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"} / 1024 / 1024 / 1024*($costram- ($costram / 100 * $costDiscount))) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"} / 1024 / 1024 / 1024 * $costpram ) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ namespace }}",
+                    "refId": "B"
+                  },
+                  {
+                    "expr": "sum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageSSD \n\nor\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageStandard",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ namespace }}",
+                    "refId": "C"
+                  },
+                  {
+                    "expr": "# CPU \n(\n sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"}*($costcpu - ($costcpu / 100 * $costDiscount))) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"}*$costpcpu) by(namespace)\n or\n count(\n count(container_spec_cpu_shares{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n#END CPU \n# Memory \n\n(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible!=\"true\"} / 1024 / 1024 / 1024*($costram- ($costram / 100 * $costDiscount))) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n(\n sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\",namespace!=\"kube-system\",cloud_google_com_gke_preemptible=\"true\"} / 1024 / 1024 / 1024 * $costpram ) by (namespace) \n or\n count(\n count(container_spec_memory_limit_bytes{namespace!=\"\",namespace!=\"kube-system\"}) by(namespace)\n ) by(namespace) -1\n)\n\n+\n\n# PV storage\n\n(\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageSSD \n\nor\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace) \n) by (namespace) / 1024 / 1024 /1024 * $costStorageStandard \n)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "legendFormat": "Total",
+                    "refId": "D"
+                  }
+                ],
+                "timeFrom": "",
+                "title": "Namespace cost allocation",
+                "transform": "table",
+                "type": "table-old"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 18
+                },
+                "id": 108,
+                "panels": [],
+                "title": "CPU Metrics",
+                "type": "row"
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 19
+                },
+                "hiddenSeries": false,
+                "id": 116,
+                "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "8.3.2",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "SUM(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"})",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "capacity",
+                    "refId": "A"
+                  },
+                  {
+                    "expr": "SUM(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"})",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "requests",
+                    "refId": "C"
+                  },
+                  {
+                    "expr": "SUM(irate(container_cpu_usage_seconds_total{id=\"/\"}[5m]))",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "usage",
+                    "refId": "B"
+                  },
+                  {
+                    "expr": "SUM(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\"}) ",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "limits",
+                    "refId": "D"
+                  }
+                ],
+                "thresholds": [],
+                "timeRegions": [],
+                "title": "Cluster CPUs",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "decimals": 1,
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 27
+                },
+                "hiddenSeries": false,
+                "id": 130,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "8.3.2",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "avg(irate(node_cpu_seconds_total{mode!=\"idle\"}[5m])) by (mode) * 100",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{mode}}",
+                    "refId": "A"
+                  }
+                ],
+                "thresholds": [],
+                "timeRegions": [],
+                "title": "CPU Mode",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "percent",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "percent",
+                    "logBase": 1,
+                    "show": false
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "text": "Avg",
+                    "value": "avg"
+                  }
+                ],
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "This table shows the comparison of CPU requests and usage by namespace",
+                "fontSize": "100%",
+                "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 35
+                },
+                "hideTimeOverride": true,
+                "id": 104,
+                "links": [],
+                "pageSize": 8,
+                "repeatDirection": "v",
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 1,
+                  "desc": true
+                },
+                "styles": [
+                  {
+                    "alias": "CPU Requests",
+                    "align": "auto",
+                    "colors": [
+                      "#fceaca",
+                      "#fce2de",
+                      "rgba(245, 54, 54, 0.9)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #A",
+                    "thresholds": [
+                      ""
+                    ],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "Node",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "node",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Time",
+                    "thresholds": [],
+                    "type": "hidden",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "CPU Requests",
+                    "align": "auto",
+                    "colorMode": "value",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(50, 172, 45, 0.97)",
+                      "#cffaff"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #B",
+                    "thresholds": [
+                      ""
+                    ],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "24h CPU Usage",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #C",
+                    "thresholds": [
+                      "30"
+                    ],
+                    "type": "number",
+                    "unit": "none"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "View namespace cost metrics",
+                    "linkUrl": "d/at-cost-analysis-namespace2/namespace-cost-metrics?&var-namespace=$__cell",
+                    "mappingType": 1,
+                    "pattern": "namespace",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace!=\"\"}) by (namespace) ",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A"
+                  },
+                  {
+                    "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",namespace!=\"\"}[24h])) by (namespace)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ namespace }}",
+                    "refId": "C"
+                  }
+                ],
+                "title": "CPU request utilization by namespace",
+                "transform": "table",
+                "type": "table-old"
+              },
+              {
+                "columns": [
+                  {
+                    "text": "Avg",
+                    "value": "avg"
+                  }
+                ],
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "This table shows the comparison of application CPU usage vs the capacity of the node (measured over last 60 minutes)",
+                "fontSize": "100%",
+                "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 35
+                },
+                "hideTimeOverride": true,
+                "id": 90,
+                "links": [],
+                "pageSize": 8,
+                "repeatDirection": "v",
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 2,
+                  "desc": true
+                },
+                "styles": [
+                  {
+                    "alias": "CPU Request Utilization",
+                    "align": "auto",
+                    "colorMode": "value",
+                    "colors": [
+                      "#ef843c",
+                      "rgba(50, 172, 45, 0.97)",
+                      "rgba(245, 54, 54, 0.9)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #A",
+                    "thresholds": [
+                      ".30",
+                      " .80"
+                    ],
+                    "type": "number",
+                    "unit": "percentunit"
+                  },
+                  {
+                    "alias": "Node",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "node",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Time",
+                    "thresholds": [],
+                    "type": "hidden",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "CPU Utilization",
+                    "align": "auto",
+                    "colorMode": "value",
+                    "colors": [
+                      "#ef843c",
+                      "rgba(50, 172, 45, 0.97)",
+                      "rgba(245, 54, 54, 0.9)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #B",
+                    "thresholds": [
+                      ".20",
+                      " .80"
+                    ],
+                    "type": "number",
+                    "unit": "percentunit"
+                  },
+                  {
+                    "alias": "24h Utilization ",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "percentunit"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "SUM(\nSUM(rate(container_cpu_usage_seconds_total[24h])) by (pod_name)\n* on (pod_name) group_left (node) \nlabel_replace(\n avg(kube_pod_info{}),\n \"pod_name\", \n \"$1\", \n \"pod\", \n \"(.+)\"\n)\n) by (node) \n/ \nsum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "B"
+                  },
+                  {
+                    "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"}) by (node) / sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) by (node)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Cluster cost & utilization by node",
+                "transform": "table",
+                "type": "table-old"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 45
+                },
+                "id": 113,
+                "panels": [],
+                "title": "Memory Metrics",
+                "type": "row"
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "fill": 1,
+                "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 46
+                },
+                "id": 117,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": false,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pluginVersion": "8.3.2",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "SUM(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"} / 1024 / 1024 / 1024)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "capacity",
+                    "refId": "A"
+                  },
+                  {
+                    "expr": "SUM(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\"} / 1024 / 1024 / 1024)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "requests",
+                    "refId": "C"
+                  },
+                  {
+                    "expr": "SUM(container_memory_usage_bytes{image!=\"\"} / 1024 / 1024 / 1024)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "usage",
+                    "refId": "B"
+                  },
+                  {
+                    "expr": "SUM(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", namespace!=\"\"} / 1024 / 1024 / 1024)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "limits",
+                    "refId": "D"
+                  }
+                ],
+                "thresholds": [],
+                "title": "Cluster memory (GB)",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "decgbytes",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "fill": 1,
+                "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 54
+                },
+                "id": 131,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": false,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pluginVersion": "8.3.2",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "1 - sum(node_memory_MemAvailable_bytes) by (node) / sum(node_memory_MemTotal_bytes) by (node)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "usage",
+                    "refId": "A"
+                  }
+                ],
+                "thresholds": [],
+                "title": "Cluster Memory Utilization",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "percentunit",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "text": "Avg",
+                    "value": "avg"
+                  }
+                ],
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "Comparison of memory requests and current usage by namespace",
+                "fontSize": "100%",
+                "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 62
+                },
+                "hideTimeOverride": true,
+                "id": 109,
+                "links": [],
+                "pageSize": 7,
+                "repeatDirection": "v",
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 1,
+                  "desc": true
+                },
+                "styles": [
+                  {
+                    "alias": "Mem Requests (GB)",
+                    "align": "auto",
+                    "colors": [
+                      "#fceaca",
+                      "#fce2de",
+                      "rgba(245, 54, 54, 0.9)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #A",
+                    "thresholds": [
+                      ""
+                    ],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "Node",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "node",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Time",
+                    "thresholds": [],
+                    "type": "hidden",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "CPU Requests",
+                    "align": "auto",
+                    "colorMode": "value",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(50, 172, 45, 0.97)",
+                      "#cffaff"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #B",
+                    "thresholds": [
+                      ""
+                    ],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "24h Mem Usage",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "#508642",
+                      "#e5ac0e"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #C",
+                    "thresholds": [
+                      ".30",
+                      ".75"
+                    ],
+                    "type": "number",
+                    "unit": "none"
+                  },
+                  {
+                    "alias": "Namespace",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "View namespace cost metrics",
+                    "linkUrl": "d/at-cost-analysis-namespace2/namespace-cost-metrics?&var-namespace=$__cell",
+                    "mappingType": 1,
+                    "pattern": "namespace",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\"} / 1024 / 1024 / 1024) by (namespace) ",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A"
+                  },
+                  {
+                    "expr": "SUM(container_memory_usage_bytes{image!=\"\",namespace!=\"\"} / 1024 / 1024 / 1024) by (namespace)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "C"
+                  }
+                ],
+                "title": "Memory requests & utilization by namespace",
+                "transform": "table",
+                "type": "table-old"
+              },
+              {
+                "columns": [
+                  {
+                    "text": "Avg",
+                    "value": "avg"
+                  }
+                ],
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "description": "Container RAM usage vs node capacity",
+                "fontSize": "100%",
+                "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 62
+                },
+                "hideTimeOverride": true,
+                "id": 114,
+                "links": [],
+                "pageSize": 8,
+                "repeatDirection": "v",
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 1,
+                  "desc": true
+                },
+                "styles": [
+                  {
+                    "alias": "RAM Requests",
+                    "align": "auto",
+                    "colorMode": "value",
+                    "colors": [
+                      "#ef843c",
+                      "rgba(50, 172, 45, 0.97)",
+                      "rgba(245, 54, 54, 0.9)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #A",
+                    "thresholds": [
+                      "30",
+                      " 80"
+                    ],
+                    "type": "number",
+                    "unit": "percentunit"
+                  },
+                  {
+                    "alias": "Node",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "node",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Time",
+                    "thresholds": [],
+                    "type": "hidden",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "RAM Usage",
+                    "align": "auto",
+                    "colorMode": "value",
+                    "colors": [
+                      "#ef843c",
+                      "rgba(50, 172, 45, 0.97)",
+                      "rgba(245, 54, 54, 0.9)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #B",
+                    "thresholds": [
+                      "25",
+                      " 80"
+                    ],
+                    "type": "number",
+                    "unit": "percent"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "SUM(label_replace(container_memory_usage_bytes{namespace!=\"\"}, \"node\", \"$1\", \"instance\",\"(.+)\")) by (node) * 100\n/\nSUM(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "B"
+                  },
+                  {
+                    "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", namespace!=\"\"}) by (node) / SUM(kube_node_status_capacity{resource=\"memory\", unit=\"byte\"}) by (node)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "A"
+                  }
+                ],
+                "title": "Node utilization of allocatable RAM",
+                "transform": "table",
+                "type": "table-old"
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 72
+                },
+                "id": 101,
+                "panels": [],
+                "title": "Storage Metrics",
+                "type": "row"
+              },
+              {
+                "columns": [
+                  {
+                    "text": "Avg",
+                    "value": "avg"
+                  }
+                ],
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "fontSize": "100%",
+                "gridPos": {
+                  "h": 9,
+                  "w": 12,
+                  "x": 0,
+                  "y": 73
+                },
+                "hideTimeOverride": true,
+                "id": 97,
+                "links": [],
+                "pageSize": 8,
+                "repeatDirection": "v",
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 4,
+                  "desc": true
+                },
+                "styles": [
+                  {
+                    "alias": "Node",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "instance",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "PVC Name",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "persistentvolumeclaim",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "Storage Class",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "storageclass",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "Cost",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "currencyUSD"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Time",
+                    "thresholds": [],
+                    "type": "hidden",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "Cost",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #A",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "currencyUSD"
+                  },
+                  {
+                    "alias": "Size (GB)",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #B",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "Usage",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #C",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "percentunit"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "SUM(container_fs_limit_bytes{id=\"/\"}) by (instance) / 1024 / 1024 / 1024 * 1.03",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "B"
+                  },
+                  {
+                    "expr": "SUM(container_fs_limit_bytes{id=\"/\"}) by (instance) / 1024 / 1024 / 1024 * 1.03 * $costStorageStandard\n",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ persistentvolumeclaim }}",
+                    "refId": "A"
+                  },
+                  {
+                    "expr": "sum(container_fs_usage_bytes{device=~\"^/dev/[sv]d[a-z][1-9]$\",id=\"/\"} / container_fs_limit_bytes{device=~\"^/dev/[sv]d[a-z][1-9]$\",id=\"/\"}) by (instance) \n",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "C"
+                  }
+                ],
+                "title": "Local Storage",
+                "transform": "table",
+                "type": "table-old"
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "fill": 1,
+                "gridPos": {
+                  "h": 9,
+                  "w": 12,
+                  "x": 12,
+                  "y": 73
+                },
+                "id": 128,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pluginVersion": "8.3.2",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "SUM(container_fs_usage_bytes{id=\"/\"}) / SUM(container_fs_limit_bytes{id=\"/\"})",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "reads",
+                    "refId": "D"
+                  }
+                ],
+                "thresholds": [],
+                "title": "Local storage utilization",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "percent",
+                    "label": "IOPS",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              },
+              {
+                "columns": [
+                  {
+                    "text": "Avg",
+                    "value": "avg"
+                  }
+                ],
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "fontSize": "100%",
+                "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 82
+                },
+                "hideTimeOverride": true,
+                "id": 94,
+                "links": [],
+                "pageSize": 10,
+                "repeatDirection": "v",
+                "scroll": true,
+                "showHeader": true,
+                "sort": {
+                  "col": 2,
+                  "desc": true
+                },
+                "styles": [
+                  {
+                    "alias": "Namespace",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "View namespace cost metrics",
+                    "linkUrl": "d/at-cost-analysis-namespace2/namespace-cost-metrics?&var-namespace=$__cell",
+                    "mappingType": 1,
+                    "pattern": "namespace",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "PVC Name",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "persistentvolumeclaim",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "Storage Class",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "storageclass",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "Cost",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "currencyUSD"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Time",
+                    "thresholds": [],
+                    "type": "hidden",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "Cost",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #A",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "currencyUSD"
+                  },
+                  {
+                    "alias": "Usage",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #B",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "percentunit"
+                  },
+                  {
+                    "alias": "Size (GB)",
+                    "align": "auto",
+                    "colors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "mappingType": 1,
+                    "pattern": "Value #C",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "sum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n * on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace)\n) by (namespace,persistentvolumeclaim,storageclass) / 1024 / 1024 /1024\n\nor\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n * on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace)\n) by (namespace,persistentvolumeclaim,storageclass) / 1024 / 1024 /1024\n\n\n",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "C"
+                  },
+                  {
+                    "expr": "sum (\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n * on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, namespace)\n) by (namespace,persistentvolumeclaim,storageclass) / 1024 / 1024 /1024 * $costStorageSSD\n\nor\n\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n * on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace)\n) by (namespace,persistentvolumeclaim,storageclass) / 1024 / 1024 /1024 * $costStorageStandard\n",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ persistentvolumeclaim }}",
+                    "refId": "A"
+                  },
+                  {
+                    "expr": "sum(kubelet_volume_stats_used_bytes) by (persistentvolumeclaim, namespace) \n/\nsum (\n sum(kube_persistentvolumeclaim_info{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace, storageclass)\n * on (persistentvolumeclaim, namespace) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{storageclass!~\".*ssd.*\"}) by (persistentvolumeclaim, namespace)\n) by (namespace,persistentvolumeclaim)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 1,
+                    "refId": "B"
+                  }
+                ],
+                "title": "Persistent Volume Claims",
+                "transform": "table",
+                "type": "table-old"
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "fill": 1,
+                "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 82
+                },
+                "id": 132,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pluginVersion": "8.3.2",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "SUM(rate(node_disk_reads_completed_total[10m])) or SUM(rate(node_disk_reads_completed[10m]))\n",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "reads",
+                    "refId": "D"
+                  },
+                  {
+                    "expr": "SUM(rate(node_disk_writes_completed_total[10m])) or SUM(rate(node_disk_writes_completed[10m]))",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "writes",
+                    "refId": "A"
+                  }
+                ],
+                "thresholds": [],
+                "title": "Disk IOPS",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "none",
+                    "label": "IOPS",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "fill": 1,
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 92
+                },
+                "id": 122,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pluginVersion": "8.3.2",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "SUM( kubelet_volume_stats_inodes_used / kubelet_volume_stats_inodes) by (persistentvolumeclaim) * 100",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "D"
+                  }
+                ],
+                "thresholds": [],
+                "title": "Inode usage",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "percent",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              },
+              {
+                "collapsed": false,
+                "gridPos": {
+                  "h": 1,
+                  "w": 24,
+                  "x": 0,
+                  "y": 101
+                },
+                "id": 127,
+                "panels": [],
+                "title": "Network",
+                "type": "row"
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": {
+                  "uid": "${datasource}"
+                },
+                "fill": 1,
+                "gridPos": {
+                  "h": 9,
+                  "w": 24,
+                  "x": 0,
+                  "y": 102
+                },
+                "id": 123,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pluginVersion": "8.3.2",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "sum (rate (node_network_transmit_bytes_total{}[60m]))\n",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "node_out",
+                    "refId": "B"
+                  },
+                  {
+                    "expr": "SUM ( rate(node_network_transmit_bytes_total{device=\"eth0\"}[60m]))",
+                    "format": "time_series",
+                    "instant": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "eth0 out",
+                    "refId": "C"
+                  }
+                ],
+                "thresholds": [],
+                "title": "Node network transmit",
+                "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "mode": "time",
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "decbytes",
+                    "logBase": 1,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                  }
+                ],
+                "yaxis": {
+                  "align": false
+                }
+              }
+            ],
+            "refresh": "15m",
+            "schemaVersion": 33,
+            "style": "dark",
+            "tags": [
+              "cost",
+              "utilization",
+              "metrics"
+            ],
+            "templating": {
+              "list": [
+                {
+                  "current": {
+                    "selected": true,
+                    "text": "23.076",
+                    "value": "23.076"
+                  },
+                  "hide": 0,
+                  "label": "CPU",
+                  "name": "costcpu",
+                  "options": [
+                    {
+                      "selected": true,
+                      "text": "23.076",
+                      "value": "23.076"
+                    }
+                  ],
+                  "query": "23.076",
+                  "skipUrlSync": false,
+                  "type": "textbox"
+                },
+                {
+                  "current": {
+                    "selected": true,
+                    "text": "5.10",
+                    "value": "5.10"
+                  },
+                  "hide": 0,
+                  "label": "PE CPU",
+                  "name": "costpcpu",
+                  "options": [
+                    {
+                      "selected": true,
+                      "text": "5.10",
+                      "value": "5.10"
+                    }
+                  ],
+                  "query": "5.10",
+                  "skipUrlSync": false,
+                  "type": "textbox"
+                },
+                {
+                  "current": {
+                    "selected": true,
+                    "text": "3.25",
+                    "value": "3.25"
+                  },
+                  "hide": 0,
+                  "label": "RAM",
+                  "name": "costram",
+                  "options": [
+                    {
+                      "selected": true,
+                      "text": "3.25",
+                      "value": "3.25"
+                    }
+                  ],
+                  "query": "3.25",
+                  "skipUrlSync": false,
+                  "type": "textbox"
+                },
+                {
+                  "current": {
+                    "selected": true,
+                    "text": "0.6862",
+                    "value": "0.6862"
+                  },
+                  "hide": 0,
+                  "label": "PE RAM",
+                  "name": "costpram",
+                  "options": [
+                    {
+                      "selected": true,
+                      "text": "0.6862",
+                      "value": "0.6862"
+                    }
+                  ],
+                  "query": "0.6862",
+                  "skipUrlSync": false,
+                  "type": "textbox"
+                },
+                {
+                  "current": {
+                    "selected": true,
+                    "text": "0.040",
+                    "value": "0.040"
+                  },
+                  "hide": 0,
+                  "label": "Storage",
+                  "name": "costStorageStandard",
+                  "options": [
+                    {
+                      "selected": true,
+                      "text": "0.040",
+                      "value": "0.040"
+                    }
+                  ],
+                  "query": "0.040",
+                  "skipUrlSync": false,
+                  "type": "textbox"
+                },
+                {
+                  "current": {
+                    "selected": true,
+                    "text": ".17",
+                    "value": ".17"
+                  },
+                  "hide": 0,
+                  "label": "SSD",
+                  "name": "costStorageSSD",
+                  "options": [
+                    {
+                      "selected": true,
+                      "text": ".17",
+                      "value": ".17"
+                    }
+                  ],
+                  "query": ".17",
+                  "skipUrlSync": false,
+                  "type": "textbox"
+                },
+                {
+                  "current": {
+                    "selected": true,
+                    "text": ".12",
+                    "value": ".12"
+                  },
+                  "hide": 0,
+                  "label": "Egress",
+                  "name": "costEgress",
+                  "options": [
+                    {
+                      "selected": true,
+                      "text": ".12",
+                      "value": ".12"
+                    }
+                  ],
+                  "query": ".12",
+                  "skipUrlSync": false,
+                  "type": "textbox"
+                },
+                {
+                  "current": {
+                    "selected": true,
+                    "text": "30",
+                    "value": "30"
+                  },
+                  "hide": 0,
+                  "label": "Discount",
+                  "name": "costDiscount",
+                  "options": [
+                    {
+                      "selected": true,
+                      "text": "30",
+                      "value": "30"
+                    }
+                  ],
+                  "query": "30",
+                  "skipUrlSync": false,
+                  "type": "textbox"
+                },
+                {
+                  "current": {
+                    "selected": false,
+                    "text": "default-kubecost",
+                    "value": "default-kubecost"
+                  },
+                  "hide": 0,
+                  "includeAll": false,
+                  "multi": false,
+                  "name": "datasource",
+                  "options": [],
+                  "query": "prometheus",
+                  "refresh": 1,
+                  "regex": "",
+                  "skipUrlSync": false,
+                  "type": "datasource"
+                }
+              ]
+            },
+            "time": {
+              "from": "now-24h",
+              "to": "now"
+            },
+            "timepicker": {
+              "hidden": false,
+              "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+              ],
+              "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+              ]
+            },
+            "timezone": "browser",
+            "title": "Cluster cost & utilization metrics",
+            "uid": "cluster-costs",
+            "version": 1,
+            "weekStart": ""
+          }
+---
+# Source: cost-analyzer/templates/grafana-dashboard-deployment-utilization-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deployment-utilization-dashboard
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+    grafana_dashboard: "1"
+  annotations:
+    {}
+data:
+    deployment-utilization.json: |-
+        {
+          "annotations": {
+            "list": [
+              {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+              }
+            ]
+          },
+          "description": "Monitors Kubernetes deployments in cluster using Prometheus and kube-state-metrics. Shows resource utilization of deployments, daemonsets, and statefulsets.",
+          "editable": true,
+          "gnetId": 8588,
+          "graphTooltip": 0,
+          "id": 2,
+          "iteration": 1586200623748,
+          "links": [],
+          "panels": [
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": true,
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": true,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 0,
+                "y": 0
+              },
+              "height": "180px",
+              "id": 1,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum (container_memory_working_set_bytes{container!=\"\",pod_name=~\"^$Deployment$Statefulset$Daemonset.*$\", kubernetes_io_hostname=~\"^$Node$\", pod_name!=\"\"}) / sum (kube_node_status_allocatable{resource=\"memory\", unit=\"byte\", node=~\"^$Node.*$\"}) * 100",
+                  "format": "time_series",
+                  "interval": "10s",
+                  "intervalFactor": 1,
+                  "refId": "A",
+                  "step": 900
+                }
+              ],
+              "thresholds": "65, 90",
+              "title": "Deployment memory usage",
+              "transparent": false,
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": true,
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": true,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 8,
+                "y": 0
+              },
+              "height": "180px",
+              "id": 2,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum (rate (container_cpu_usage_seconds_total{pod_name=~\"^$Deployment$Statefulset$Daemonset.*$\", kubernetes_io_hostname=~\"^$Node$\"}[2m])) / sum (machine_cpu_cores{kubernetes_io_hostname=~\"^$Node$\"}) * 100",
+                  "format": "time_series",
+                  "interval": "10s",
+                  "intervalFactor": 1,
+                  "refId": "A",
+                  "step": 900
+                }
+              ],
+              "thresholds": "65, 90",
+              "title": "Deployment CPU usage",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": true,
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "format": "percent",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": true,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 16,
+                "y": 0
+              },
+              "height": "180px",
+              "id": 3,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "(((sum(kube_deployment_status_replicas{deployment=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)) + (sum(kube_statefulset_replicas{statefulset=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)) + (sum(kube_daemonset_status_desired_number_scheduled{daemonset=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0))) - ((sum(kube_deployment_status_replicas_available{deployment=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)) + (sum(kube_statefulset_status_replicas{statefulset=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)) + (sum(kube_daemonset_status_number_ready{daemonset=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)))) / ((sum(kube_deployment_status_replicas{deployment=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)) + (sum(kube_statefulset_replicas{statefulset=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)) + (sum(kube_daemonset_status_desired_number_scheduled{daemonset=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0))) * 100",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 1800
+                }
+              ],
+              "thresholds": "1,30",
+              "title": "Unavailable Replicas",
+              "type": "singlestat",
+              "valueFontSize": "80%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "format": "bytes",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 0,
+                "y": 5
+              },
+              "height": "100px",
+              "id": 4,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum(container_memory_working_set_bytes{container!=\"\",pod_name=~\"^$Deployment$Statefulset$Daemonset.*$\", kubernetes_io_hostname=~\"^$Node$\", pod_name!=\"\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 1800
+                }
+              ],
+              "thresholds": "",
+              "title": "Used",
+              "type": "singlestat",
+              "valueFontSize": "50%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "format": "bytes",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 4,
+                "y": 5
+              },
+              "height": "100px",
+              "id": 5,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum (kube_node_status_allocatable{resource=\"memory\", unit=\"byte\", node=~\"^$Node.*$\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 1800
+                }
+              ],
+              "thresholds": "",
+              "title": "Total",
+              "type": "singlestat",
+              "valueFontSize": "50%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 8,
+                "y": 5
+              },
+              "height": "100px",
+              "id": 6,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": " cores",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum (rate (container_cpu_usage_seconds_total{pod_name=~\"^$Deployment$Statefulset$Daemonset.*$\", kubernetes_io_hostname=~\"^$Node$\"}[5m]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 1800
+                }
+              ],
+              "thresholds": "",
+              "title": "Used",
+              "type": "singlestat",
+              "valueFontSize": "50%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 12,
+                "y": 5
+              },
+              "height": "100px",
+              "id": 7,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": " cores",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "sum (machine_cpu_cores{kubernetes_io_hostname=~\"^$Node$\"})",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 1800
+                }
+              ],
+              "thresholds": "",
+              "title": "Total",
+              "type": "singlestat",
+              "valueFontSize": "50%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "avg"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 16,
+                "y": 5
+              },
+              "height": "100px",
+              "id": 8,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "(sum(kube_deployment_status_replicas_available{deployment=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)) + (sum(kube_statefulset_status_replicas{statefulset=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)) + (sum(kube_daemonset_status_number_ready{daemonset=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "refId": "A",
+                  "step": 1800
+                }
+              ],
+              "thresholds": "",
+              "title": "Available (cluster)",
+              "type": "singlestat",
+              "valueFontSize": "50%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 20,
+                "y": 5
+              },
+              "height": "100px",
+              "id": 9,
+              "interval": null,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "(sum(kube_deployment_status_replicas{deployment=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)) + (sum(kube_statefulset_replicas{statefulset=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0)) + (sum(kube_daemonset_status_desired_number_scheduled{daemonset=~\".*$Deployment$Statefulset$Daemonset\"}) or vector(0))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{ $Daemonset }}",
+                  "refId": "A",
+                  "step": 1800
+                }
+              ],
+              "thresholds": "",
+              "title": "Total (cluster)",
+              "type": "singlestat",
+              "valueFontSize": "50%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 3,
+              "editable": true,
+              "error": false,
+              "fill": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 11,
+                "w": 24,
+                "x": 0,
+                "y": 8
+              },
+              "height": "",
+              "id": 10,
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": true,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                {
+                  "alias": "/avlbl.*/",
+                  "yaxis": 2
+                }
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum (irate (container_cpu_usage_seconds_total{container!=\"\",image!=\"\",name=~\"^k8s_.*\",io_kubernetes_container_name!=\"POD\",pod_name=~\"^$Deployment$Statefulset$Daemonset.*$\",kubernetes_io_hostname=~\"^$Node$\"}[5m])) by (pod_name,kubernetes_io_hostname)",
+                  "format": "time_series",
+                  "hide": false,
+                  "interval": "10s",
+                  "intervalFactor": 1,
+                  "legendFormat": "usage: {{ kubernetes_io_hostname }} | {{ pod_name }} ",
+                  "metric": "container_cpu",
+                  "refId": "A",
+                  "step": 60
+                },
+                {
+                  "expr": "sum (kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"^$Deployment$Statefulset$Daemonset.*$\",node=~\"^$Node$\"}) by (pod,node)",
+                  "format": "time_series",
+                  "hide": false,
+                  "intervalFactor": 2,
+                  "legendFormat": "rqst: {{ node }} | {{ pod }}",
+                  "refId": "B",
+                  "step": 120
+                },
+                {
+                  "expr": "sum ((kube_node_status_allocatable{resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})) by (node)",
+                  "format": "time_series",
+                  "hide": true,
+                  "intervalFactor": 2,
+                  "legendFormat": "avlbl: {{ node }}",
+                  "refId": "C",
+                  "step": 30
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "CPU usage & requests",
+              "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "none",
+                  "label": "cores",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "fill": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 13,
+                "w": 24,
+                "x": 0,
+                "y": 19
+              },
+              "id": 11,
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                {
+                  "alias": "/^avlbl.*$/",
+                  "yaxis": 2
+                }
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "max (container_memory_working_set_bytes{container!=\"POD\",container!=\"\",id!=\"/\",pod_name=~\"^$Deployment$Statefulset$Daemonset.*$\",kubernetes_io_hostname=~\"^$Node$\"}) by (pod_name,kubernetes_io_hostname)",
+                  "format": "time_series",
+                  "hide": false,
+                  "interval": "10s",
+                  "intervalFactor": 1,
+                  "legendFormat": "usage: {{kubernetes_io_hostname }} | {{ pod_name }}",
+                  "metric": "container_memory_usage:sort_desc",
+                  "refId": "A",
+                  "step": 60
+                },
+                {
+                  "expr": "sum ((kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"^$Deployment$Statefulset$Daemonset.*$\",node=~\"^$Node$\"})) by (pod,node)",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "rqst: {{ node }} | {{ pod }}",
+                  "refId": "B",
+                  "step": 120
+                },
+                {
+                  "expr": "sum ((kube_node_status_allocatable{resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})) by (node)",
+                  "format": "time_series",
+                  "hide": true,
+                  "intervalFactor": 2,
+                  "legendFormat": "avlbl: {{ node }}",
+                  "refId": "C",
+                  "step": 30
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Memory usage & requests",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 32
+              },
+              "id": 12,
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "100 * (kubelet_volume_stats_used_bytes{kubernetes_io_hostname=~\"^$Node$\", persistentvolumeclaim=~\".*$Deployment$Statefulset$Daemonset.*$\"} / kubelet_volume_stats_capacity_bytes{kubernetes_io_hostname=~\"^$Node$\", persistentvolumeclaim=~\".*$Deployment$Statefulset$Daemonset.*$\"})",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{ persistentvolumeclaim }} | {{ kubernetes_io_hostname }}",
+                  "refId": "A",
+                  "step": 120
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Disk Usage",
+              "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "fill": 1,
+              "grid": {},
+              "gridPos": {
+                "h": 13,
+                "w": 24,
+                "x": 0,
+                "y": 41
+              },
+              "id": 13,
+              "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "max": true,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum (rate (container_network_receive_bytes_total{id!=\"/\",pod_name=~\"^$Deployment$Statefulset$Daemonset.*$\",kubernetes_io_hostname=~\"^$Node$\"}[2m])) by (pod_name, kubernetes_io_hostname)",
+                  "format": "time_series",
+                  "interval": "10s",
+                  "intervalFactor": 1,
+                  "legendFormat": "-> {{ kubernetes_io_hostname }} | {{ pod_name }}",
+                  "metric": "network",
+                  "refId": "A",
+                  "step": 60
+                },
+                {
+                  "expr": "- sum( rate (container_network_transmit_bytes_total{id!=\"/\",pod_name=~\"^$Deployment$Statefulset$Daemonset.*$\",kubernetes_io_hostname=~\"^$Node$\"}[2m])) by (pod_name, kubernetes_io_hostname)",
+                  "format": "time_series",
+                  "interval": "10s",
+                  "intervalFactor": 1,
+                  "legendFormat": "<- {{ kubernetes_io_hostname }} | {{ pod_name }}",
+                  "metric": "network",
+                  "refId": "B",
+                  "step": 60
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "All processes network I/O",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "Bps",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            }
+          ],
+          "refresh": false,
+          "schemaVersion": 16,
+          "style": "dark",
+          "tags": [
+            "cost",
+            "utilization",
+            "metrics"
+          ],
+          "templating": {
+            "list": [
+              {
+                "allValue": "()",
+                "current": {
+                  "selected": false,
+                  "tags": [],
+                  "text": "All",
+                  "value": "$__all"
+                },
+                "datasource": "${datasource}",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "Deployment",
+                "options": [],
+                "query": "label_values(deployment)",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "allValue": "()",
+                "current": {
+                  "text": "All",
+                  "value": "$__all"
+                },
+                "datasource": "${datasource}",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "Statefulset",
+                "options": [],
+                "query": "label_values(statefulset)",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "allValue": "()",
+                "current": {
+                  "text": "All",
+                  "value": "$__all"
+                },
+                "datasource": "${datasource}",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "Daemonset",
+                "options": [],
+                "query": "label_values(daemonset)",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "allValue": ".*",
+                "current": {
+                  "text": "All",
+                  "value": "$__all"
+                },
+                "datasource": "${datasource}",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "Node",
+                "options": [],
+                "query": "label_values(kubernetes_io_hostname)",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "current": {
+                  "selected": true,
+                  "text": "default-kubecost",
+                  "value": "default-kubecost"
+                },
+                "error": null,
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+              }
+            ]
+          },
+          "time": {
+            "from": "now-24h",
+            "to": "now"
+          },
+          "timepicker": {
+            "refresh_intervals": [
+              "5s",
+              "10s",
+              "30s",
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "2h",
+              "1d"
+            ],
+            "time_options": [
+              "5m",
+              "15m",
+              "1h",
+              "6h",
+              "12h",
+              "24h",
+              "2d",
+              "7d",
+              "30d"
+            ]
+          },
+          "timezone": "browser",
+          "title": "Deployment/Statefulset/Daemonset utilization metrics",
+          "uid": "deployment-metrics",
+          "version": 1
+        }
+---
+# Source: cost-analyzer/templates/grafana-dashboard-label-cost-utilization-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: label-cost-dashboard
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+    grafana_dashboard: "1"
+  annotations:
+    {}
+data:
+    label-cost-utilization.json: |-
+        {
+          "annotations": {
+            "list": [
+              {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                  "limit": 100,
+                  "matchAny": false,
+                  "tags": [],
+                  "type": "dashboard"
+                },
+                "type": "dashboard"
+              }
+            ]
+          },
+          "editable": true,
+          "fiscalYearStartMonth": 0,
+          "graphTooltip": 0,
+          "iteration": 1645115160709,
+          "links": [],
+          "liveNow": false,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Monthly projected CPU cost given last 10m",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 0,
+                "y": 0
+              },
+              "hideTimeOverride": true,
+              "id": 15,
+              "links": [],
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "P0C970EB638C812D0"
+                  },
+                  "exemplar": false,
+                  "expr": "sum(\n  avg(container_cpu_allocation) by (pod,node)\n\n  * on (node) group_left()\n  avg(avg_over_time(node_cpu_hourly_cost[10m])) by (node)\n\n  * on (pod) group_left()\n  label_replace(\n    max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod),\n    \"pod_name\",\n    \"$1\", \n    \"pod\", \n    \"(.+)\"\n  )\n) * 730",
+                  "format": "time_series",
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " {{ node }}",
+                  "refId": "A"
+                }
+              ],
+              "timeFrom": "15m",
+              "title": "CPU Cost",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Based on CPU usage over last 24 hours",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 6,
+                "y": 0
+              },
+              "hideTimeOverride": true,
+              "id": 16,
+              "links": [],
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "P0C970EB638C812D0"
+                  },
+                  "exemplar": false,
+                  "expr": "sum(\n  avg(container_memory_allocation_bytes) by (pod,node) / 1024 / 1024 / 1024\n\n  * on (node) group_left()\n  avg(avg_over_time(node_ram_hourly_cost[10m])) by (node)\n\n  * on (pod) group_left()\n  label_replace(\n    max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod),\n    \"pod_name\",\n    \"$1\", \n    \"pod\", \n    \"(.+)\"\n  )\n) * 730",
+                  "format": "time_series",
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " {{ node }}",
+                  "refId": "A"
+                }
+              ],
+              "timeFrom": "15m",
+              "title": "Memory Cost",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 12,
+                "y": 0
+              },
+              "hideTimeOverride": true,
+              "id": 21,
+              "links": [],
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "P0C970EB638C812D0"
+                  },
+                  "exemplar": false,
+                  "expr": "sum(\n sum(kube_persistentvolumeclaim_info{storageclass!=\".*ssd.*\"}) by (persistentvolumeclaim, storageclass)\n * on (persistentvolumeclaim) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim)\n * on (persistentvolumeclaim) group_left(label_app)\n max(kube_persistentvolumeclaim_labels{label_$label=~\"$label_value\"}) by (persistentvolumeclaim) or up * 0\n) / 1024 / 1024 /1024 * .04 \n\n+\n\nsum(\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, storageclass)\n * on (persistentvolumeclaim) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim)\n * on (persistentvolumeclaim) group_left(label_app)\n max(kube_persistentvolumeclaim_labels{label_$label=~\"$label_value\"}) by (persistentvolumeclaim) or up * 0\n) / 1024 / 1024 /1024 * .17 \n",
+                  "format": "time_series",
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " {{ node }}",
+                  "refId": "A"
+                }
+              ],
+              "timeFrom": "15m",
+              "title": "Storage Cost",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Cost of memory + CPU usage",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 18,
+                "y": 0
+              },
+              "hideTimeOverride": true,
+              "id": 20,
+              "links": [],
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "P0C970EB638C812D0"
+                  },
+                  "exemplar": false,
+                  "expr": "# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CPU ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\nsum(\n  avg(container_cpu_allocation) by (pod,node)\n\n  * on (node) group_left()\n  avg(avg_over_time(node_cpu_hourly_cost[10m])) by (node)\n\n  * on (pod) group_left()\n  label_replace(\n    max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod),\n    \"pod_name\",\n    \"$1\", \n    \"pod\", \n    \"(.+)\"\n  )\n) * 730\n\n#END CPU\n+\n\n# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Memory ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\nsum(\n  avg(container_memory_allocation_bytes) by (pod,node) / 1024 / 1024 / 1024\n\n  * on (node) group_left()\n  avg(avg_over_time(node_ram_hourly_cost[10m])) by (node)\n\n  * on (pod) group_left()\n  label_replace(\n    max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod),\n    \"pod_name\",\n    \"$1\", \n    \"pod\", \n    \"(.+)\"\n  )\n) * 730\n\n# END MEMORY\n\n+\n\n# ~~~~~~~~~~~~~~~~~~~~~~~~~~~ STORAGE ~~~~~~~~~~~~~~~~~~~~~~~~~\n\nsum(\n sum(kube_persistentvolumeclaim_info{storageclass!=\".*ssd.*\"}) by (persistentvolumeclaim, storageclass)\n * on (persistentvolumeclaim) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim)\n * on (persistentvolumeclaim) group_left(label_app)\n max(kube_persistentvolumeclaim_labels{label_$label=~\"$label_value\"}) by (persistentvolumeclaim) or up * 0\n) / 1024 / 1024 /1024 * .04 \n\n+\n\nsum(\n sum(kube_persistentvolumeclaim_info{storageclass=~\".*ssd.*\"}) by (persistentvolumeclaim, storageclass)\n * on (persistentvolumeclaim) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim)\n * on (persistentvolumeclaim) group_left(label_app)\n max(kube_persistentvolumeclaim_labels{label_$label=~\"$label_value\"}) by (persistentvolumeclaim) or up * 0\n) / 1024 / 1024 /1024 * .17 \n\n\n# END STORAGE\n",
+                  "format": "time_series",
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " {{ node }}",
+                  "refId": "A"
+                }
+              ],
+              "timeFrom": "15m",
+              "title": "Total Cost",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 0,
+                "y": 5
+              },
+              "id": 10,
+              "links": [],
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "expr": "sum(\n sum (kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"}) by (pod)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod)\n or up * 0\n) ",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU Request",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 3,
+                "y": 5
+              },
+              "id": 17,
+              "links": [],
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "expr": "sum(\n label_replace(\n sum(rate(container_cpu_usage_seconds_total{image!=\"\",container_name!=\"POD\"}[1h])) by (kubernetes_io_hostname,pod_name),\n \"node\",\n \"$1\", \n \"kubernetes_io_hostname\", \n \"(.+)\"\n ) \n * on (pod_name) group_left()\n label_replace(\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod),\n \"pod_name\",\n \"$1\", \n \"pod\", \n \"(.+)\"\n ) or up * 0\n) ",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU Used",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 6,
+                "y": 5
+              },
+              "id": 11,
+              "links": [],
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "expr": "sum(\n sum (kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\"}) by (pod)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod)\n or up * 0\n) ",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory Request",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 9,
+                "y": 5
+              },
+              "id": 18,
+              "links": [],
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "expr": "sum(\n label_replace(\n sum (container_memory_working_set_bytes{pod_name!=\"\",container!=\"POD\",container!=\"\"}) by (pod_name),\n \"pod\",\n \"$1\", \n \"pod_name\", \n \"(.+)\")\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod)\n or up * 0\n)",
+                  "format": "time_series",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory Usage",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 12,
+                "y": 5
+              },
+              "id": 22,
+              "links": [],
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "expr": "sum(\n max(kube_persistentvolumeclaim_info) by (persistentvolumeclaim, storageclass)\n * on (persistentvolumeclaim) group_right(storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim)\n * on (persistentvolumeclaim) group_left(label_app)\n max(kube_persistentvolumeclaim_labels{label_$label=~\"$label_value\"}) by (persistentvolumeclaim) or up * 0\n) \n",
+                  "format": "time_series",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "refId": "A"
+                }
+              ],
+              "title": "Storage Request",
+              "type": "stat"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 9
+              },
+              "hiddenSeries": false,
+              "id": 8,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "options": {
+                "alertThreshold": true
+              },
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(\n label_replace(\n sum (kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\"}) by (pod, container)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod,container),\n \"container_name\",\n \"$1\", \n \"container\", \n \"(.+)\"\n )\n) \n",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "limit",
+                  "refId": "C"
+                },
+                {
+                  "expr": "sum(\n label_replace(\n sum (kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"}) by (pod, container)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod,container),\n \"container_name\",\n \"$1\", \n \"container\", \n \"(.+)\"\n )\n) \n",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "request",
+                  "refId": "B"
+                },
+                {
+                  "expr": "sum(\n label_replace(\n sum (rate (container_cpu_usage_seconds_total{image!=\"\",container!=\"POD\",container!=\"\"}[10m])) by (container,pod),\n \"pod\", \n \"$1\", \n \"pod_name\", \n \"(.+)\"\n )\n * on (pod) group_left (label_$label)\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod,container)\n)\n",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "usage",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeRegions": [],
+              "title": "CPU Usage vs Requests vs Limits",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "logBase": 1,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "logBase": 1,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 9
+              },
+              "hiddenSeries": false,
+              "id": 23,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "options": {
+                "alertThreshold": true
+              },
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum(\n label_replace(\n sum (kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\"}) by (pod, container)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod,container),\n \"container_name\",\n \"$1\", \n \"container\", \n \"(.+)\"\n )\n) \n",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "limit",
+                  "refId": "C"
+                },
+                {
+                  "expr": "sum(\n label_replace(\n sum (kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\"}) by (pod, container)\n * on (pod) group_left()\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod,container),\n \"container_name\",\n \"$1\", \n \"container\", \n \"(.+)\"\n )\n) \n",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "request",
+                  "refId": "B"
+                },
+                {
+                  "expr": "sum(\n label_replace(\n sum (container_memory_working_set_bytes{container!=\"\",container!=\"POD\"}) by (container,pod),\n \"pod\", \n \"$1\", \n \"pod_name\", \n \"(.+)\"\n )\n * on (pod) group_left (label_$label)\n max(kube_pod_labels{label_$label=~\"$label_value\"}) by (pod,container)\n)\n",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "usage",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeRegions": [],
+              "title": "Memory Usage vs Requests vs Limits",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "logBase": 1,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "logBase": 1,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false
+              }
+            }
+          ],
+          "refresh": false,
+          "schemaVersion": 34,
+          "style": "dark",
+          "tags": [
+            "cost",
+            "utilization",
+            "metrics"
+          ],
+          "templating": {
+            "list": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "filters": [],
+                "hide": 0,
+                "label": "",
+                "name": "Filters",
+                "skipUrlSync": false,
+                "type": "adhoc"
+              },
+              {
+                "current": {
+                  "tags": [],
+                  "text": "app",
+                  "value": "app"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "Label",
+                "multi": false,
+                "name": "label",
+                "options": [
+                  {
+                    "selected": true,
+                    "text": "app",
+                    "value": "app"
+                  },
+                  {
+                    "selected": false,
+                    "text": "tier",
+                    "value": "tier"
+                  },
+                  {
+                    "selected": false,
+                    "text": "component",
+                    "value": "component"
+                  },
+                  {
+                    "selected": false,
+                    "text": "release",
+                    "value": "release"
+                  },
+                  {
+                    "selected": false,
+                    "text": "name",
+                    "value": "name"
+                  },
+                  {
+                    "selected": false,
+                    "text": "team",
+                    "value": "team"
+                  },
+                  {
+                    "selected": false,
+                    "text": "department",
+                    "value": "department"
+                  },
+                  {
+                    "selected": false,
+                    "text": "owner",
+                    "value": "owner"
+                  },
+                  {
+                    "selected": false,
+                    "text": "contact",
+                    "value": "contact"
+                  }
+                ],
+                "query": "app, tier, component, release, name, team, department, owner, contact",
+                "skipUrlSync": false,
+                "type": "custom"
+              },
+              {
+                "allValue": ".*",
+                "current": {
+                  "selected": false,
+                  "text": "All",
+                  "value": "$__all"
+                },
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Value",
+                "multi": false,
+                "name": "label_value",
+                "options": [],
+                "query": {
+                  "query": "query_result(SUM(kube_pod_labels{label_$label!=\"\",namespace!=\"kube-system\"}) by (label_$label))",
+                  "refId": "default-kubecost-label_value-Variable-Query"
+                },
+                "refresh": 1,
+                "regex": "/label_$label=\\\"(.*?)(\\\")/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "allValue": "()",
+                "current": {
+                  "selected": false,
+                  "text": "All",
+                  "value": "$__all"
+                },
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "",
+                "multi": false,
+                "name": "Deployments",
+                "options": [],
+                "query": {
+                  "query": "label_values(deployment)",
+                  "refId": "default-kubecost-Deployments-Variable-Query"
+                },
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "current": {
+                  "selected": false,
+                  "text": "All",
+                  "value": "$__all"
+                },
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "multi": false,
+                "name": "Secondary",
+                "options": [],
+                "query": {
+                  "query": "query_result(kube_pod_labels)",
+                  "refId": "default-kubecost-Secondary-Variable-Query"
+                },
+                "refresh": 1,
+                "regex": "/.+?label_([^=]*).*/",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "current": {
+                  "selected": false,
+                  "text": "default-kubecost",
+                  "value": "default-kubecost"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "multi": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+              }
+            ]
+          },
+          "time": {
+            "from": "now-24h",
+            "to": "now"
+          },
+          "timepicker": {
+            "refresh_intervals": [
+              "5s",
+              "10s",
+              "30s",
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "2h",
+              "1d"
+            ],
+            "time_options": [
+              "5m",
+              "15m",
+              "1h",
+              "6h",
+              "12h",
+              "24h",
+              "2d",
+              "7d",
+              "30d"
+            ]
+          },
+          "timezone": "",
+          "title": "Label costs & utilization",
+          "uid": "lWMhIA-ik",
+          "version": 1,
+          "weekStart": ""
+        }
+---
+# Source: cost-analyzer/templates/grafana-dashboard-namespace-utilization-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: namespace-utilization-dashboard
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+    grafana_dashboard: "1"
+  annotations:
+    {}
+data:
+    namespace-utilization.json: |-
+        {
+        	"annotations":{
+        		"list":[
+        			{
+        				"builtIn":1,
+        				"datasource":"-- Grafana --",
+        				"enable":true,
+        				"hide":true,
+        				"iconColor":"rgba(0, 211, 255, 1)",
+        				"name":"Annotations & Alerts",
+        				"type":"dashboard"
+        			}
+        		]
+        	},
+        	"description":"A dashboard to help with utilization and resource allocation",
+        	"editable":true,
+        	"gnetId":8673,
+        	"graphTooltip":0,
+        	"id":9,
+        	"iteration":1553150922105,
+        	"links":[
+
+        	],
+        	"panels":[
+        		{
+        			"columns":[
+        				{
+        					"text":"Avg",
+        					"value":"avg"
+        				}
+        			],
+        			"datasource":"${datasource}",
+        			"fontSize":"100%",
+        			"gridPos":{
+        				"h":9,
+        				"w":16,
+        				"x":0,
+        				"y":0
+        			},
+        			"hideTimeOverride":true,
+        			"id":73,
+        			"links":[
+
+        			],
+        			"pageSize":8,
+        			"repeat":null,
+        			"repeatDirection":"v",
+        			"scroll":true,
+        			"showHeader":true,
+        			"sort":{
+        				"col":2,
+        				"desc":false
+        			},
+        			"styles":[
+        				{
+        					"alias":"Pod",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(50, 172, 45, 0.97)",
+        						"#c15c17"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"link":false,
+        					"linkTooltip":"",
+        					"linkUrl":"",
+        					"pattern":"pod_name",
+        					"thresholds":[
+        						"30",
+        						"80"
+        					],
+        					"type":"string",
+        					"unit":"currencyUSD"
+        				},
+        				{
+        					"alias":"RAM",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"pattern":"Value #B",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"decbytes"
+        				},
+        				{
+        					"alias":"CPU %",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #A",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"percent"
+        				},
+        				{
+        					"alias":"",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Time",
+        					"thresholds":[
+
+        					],
+        					"type":"hidden",
+        					"unit":"short"
+        				},
+        				{
+        					"alias":"Storage",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #C",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"currencyUSD"
+        				},
+        				{
+        					"alias":"Total",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #D",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"currencyUSD"
+        				},
+        				{
+        					"alias":"CPU Utilization",
+        					"colorMode":"value",
+        					"colors":[
+        						"#bf1b00",
+        						"rgba(50, 172, 45, 0.97)",
+        						"#ef843c"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #E",
+        					"thresholds":[
+        						"30",
+        						"80"
+        					],
+        					"type":"number",
+        					"unit":"percent"
+        				},
+        				{
+        					"alias":"RAM Utilization",
+        					"colorMode":"value",
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(50, 172, 45, 0.97)",
+        						"#ef843c"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #F",
+        					"thresholds":[
+        						"30",
+        						"80"
+        					],
+        					"type":"number",
+        					"unit":"percent"
+        				}
+        			],
+        			"targets":[
+        				{
+        					"expr":"sum (rate (container_cpu_usage_seconds_total{namespace=\"$namespace\"}[10m])) by (pod_name) * 100",
+        					"format":"table",
+        					"hide":false,
+        					"instant":true,
+        					"interval":"",
+        					"intervalFactor":1,
+        					"legendFormat":"{{ pod_name }}",
+        					"refId":"A"
+        				},
+        				{
+        					"expr":"sum (avg_over_time (container_memory_working_set_bytes{namespace=\"$namespace\", container_name!=\"POD\"}[10m])) by (pod_name)",
+        					"format":"table",
+        					"hide":false,
+        					"instant":true,
+        					"intervalFactor":1,
+        					"legendFormat":"{{ pod_name }}",
+        					"refId":"B"
+        				}
+        			],
+        			"timeFrom":"1M",
+        			"timeShift":null,
+        			"title":"Pod utilization analysis",
+        			"transform":"table",
+        			"transparent":false,
+        			"type":"table"
+        		},
+        		{
+        			"columns":[
+        				{
+        					"text":"Avg",
+        					"value":"avg"
+        				}
+        			],
+        			"datasource":"${datasource}",
+        			"fontSize":"100%",
+        			"gridPos":{
+        				"h":9,
+        				"w":8,
+        				"x":16,
+        				"y":0
+        			},
+        			"hideTimeOverride":true,
+        			"id":90,
+        			"links":[
+
+        			],
+        			"pageSize":8,
+        			"repeatDirection":"v",
+        			"scroll":true,
+        			"showHeader":true,
+        			"sort":{
+        				"col":4,
+        				"desc":true
+        			},
+        			"styles":[
+        				{
+        					"alias":"Namespace",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"namespace",
+        					"thresholds":[
+
+        					],
+        					"type":"hidden",
+        					"unit":"short"
+        				},
+        				{
+        					"alias":"PVC Name",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"persistentvolumeclaim",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"short"
+        				},
+        				{
+        					"alias":"Storage Class",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"storageclass",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"short"
+        				},
+        				{
+        					"alias":"Size",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":1,
+        					"mappingType":1,
+        					"pattern":"Value",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"gbytes"
+        				},
+        				{
+        					"alias":"",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Time",
+        					"thresholds":[
+
+        					],
+        					"type":"hidden",
+        					"unit":"short"
+        				}
+        			],
+        			"targets":[
+        				{
+        					"expr":"sum (\n sum(kube_persistentvolumeclaim_info) by (persistentvolumeclaim, namespace, storageclass)\n + on (persistentvolumeclaim, namespace) group_right (storageclass)\n sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace=~\"$namespace\"}) by (persistentvolumeclaim, namespace)\n) by (namespace,persistentvolumeclaim,storageclass) / 1024 / 1024 /1024 ",
+        					"format":"table",
+        					"hide":false,
+        					"instant":true,
+        					"interval":"",
+        					"intervalFactor":1,
+        					"legendFormat":"{{ persistentvolumeclaim }}",
+        					"refId":"A"
+        				}
+        			],
+        			"timeFrom":null,
+        			"timeShift":null,
+        			"title":"Persistent Volume Claims",
+        			"transform":"table",
+        			"transparent":false,
+        			"type":"table"
+        		},
+        		{
+        			"aliasColors":{
+
+        			},
+        			"bars":false,
+        			"dashLength":10,
+        			"dashes":false,
+        			"datasource":"${datasource}",
+        			"description":"CPU requests by pod divided by the rate of CPU usage over the last hour",
+        			"fill":1,
+        			"gridPos":{
+        				"h":9,
+        				"w":24,
+        				"x":0,
+        				"y":9
+        			},
+        			"id":100,
+        			"legend":{
+        				"avg":false,
+        				"current":false,
+        				"max":false,
+        				"min":false,
+        				"show":true,
+        				"total":false,
+        				"values":false
+        			},
+        			"lines":true,
+        			"linewidth":1,
+        			"links":[
+
+        			],
+        			"nullPointMode":"null",
+        			"percentage":false,
+        			"pointradius":5,
+        			"points":false,
+        			"renderer":"flot",
+        			"seriesOverrides":[
+
+        			],
+        			"spaceLength":10,
+        			"stack":false,
+        			"steppedLine":false,
+        			"targets":[
+        				{
+        					"expr":"topk(10,\n label_replace(\n sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace=\"$namespace\"}) by (pod),\n \"pod_name\", \n \"$1\", \n \"pod\", \n \"(.+)\"\n ) \n/ on (pod_name) sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",pod_name=~\".+\"}[1h])) by (pod_name))",
+        					"format":"time_series",
+        					"intervalFactor":1,
+        					"refId":"A"
+        				}
+        			],
+        			"thresholds":[
+
+        			],
+        			"timeFrom":null,
+        			"timeShift":null,
+        			"title":"Ratio of CPU requests to usage (Top 10 pods)",
+        			"tooltip":{
+        				"shared":true,
+        				"sort":0,
+        				"value_type":"individual"
+        			},
+        			"type":"graph",
+        			"xaxis":{
+        				"buckets":null,
+        				"mode":"time",
+        				"name":null,
+        				"show":true,
+        				"values":[
+
+        				]
+        			},
+        			"yaxes":[
+        				{
+        					"format":"short",
+        					"label":null,
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":true
+        				},
+        				{
+        					"format":"short",
+        					"label":null,
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":true
+        				}
+        			],
+        			"yaxis":{
+        				"align":false,
+        				"alignLevel":null
+        			}
+        		},
+        		{
+        			"aliasColors":{
+
+        			},
+        			"bars":false,
+        			"dashLength":10,
+        			"dashes":false,
+        			"datasource":"${datasource}",
+        			"decimals":3,
+        			"description":"This panel shows historical utilization as an average across all pods in this namespace. It only accounts for currently deployed pods",
+        			"editable":true,
+        			"error":false,
+        			"fill":0,
+        			"grid":{
+
+        			},
+        			"gridPos":{
+        				"h":6,
+        				"w":12,
+        				"x":0,
+        				"y":18
+        			},
+        			"height":"",
+        			"id":94,
+        			"isNew":true,
+        			"legend":{
+        				"alignAsTable":false,
+        				"avg":false,
+        				"current":false,
+        				"hideEmpty":false,
+        				"hideZero":false,
+        				"max":false,
+        				"min":false,
+        				"rightSide":false,
+        				"show":false,
+        				"sideWidth":null,
+        				"sort":"current",
+        				"sortDesc":true,
+        				"total":false,
+        				"values":true
+        			},
+        			"lines":true,
+        			"linewidth":2,
+        			"links":[
+
+        			],
+        			"nullPointMode":"connected",
+        			"percentage":false,
+        			"pointradius":5,
+        			"points":false,
+        			"renderer":"flot",
+        			"seriesOverrides":[
+
+        			],
+        			"spaceLength":10,
+        			"stack":false,
+        			"steppedLine":true,
+        			"targets":[
+        				{
+        					"expr":"sum (rate (container_cpu_usage_seconds_total{namespace=\"$namespace\"}[10m])) by (namespace)\n",
+        					"format":"time_series",
+        					"hide":false,
+        					"instant":false,
+        					"interval":"10s",
+        					"intervalFactor":1,
+        					"legendFormat":"cpu utilization",
+        					"metric":"container_cpu",
+        					"refId":"A",
+        					"step":10
+        				}
+        			],
+        			"thresholds":[
+
+        			],
+        			"timeFrom":"",
+        			"timeShift":null,
+        			"title":"Overall CPU Utilization",
+        			"tooltip":{
+        				"msResolution":true,
+        				"shared":true,
+        				"sort":2,
+        				"value_type":"cumulative"
+        			},
+        			"type":"graph",
+        			"xaxis":{
+        				"buckets":null,
+        				"mode":"time",
+        				"name":null,
+        				"show":true,
+        				"values":[
+
+        				]
+        			},
+        			"yaxes":[
+        				{
+        					"decimals":null,
+        					"format":"percent",
+        					"label":"",
+        					"logBase":1,
+        					"max":"110",
+        					"min":"0",
+        					"show":true
+        				},
+        				{
+        					"format":"short",
+        					"label":null,
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":false
+        				}
+        			],
+        			"yaxis":{
+        				"align":false,
+        				"alignLevel":null
+        			}
+        		},
+        		{
+        			"aliasColors":{
+
+        			},
+        			"bars":false,
+        			"dashLength":10,
+        			"dashes":false,
+        			"datasource":"${datasource}",
+        			"decimals":2,
+        			"description":"This panel shows historical utilization as an average across all pods in this namespace. It only accounts for currently deployed pods",
+        			"editable":true,
+        			"error":false,
+        			"fill":0,
+        			"grid":{
+
+        			},
+        			"gridPos":{
+        				"h":6,
+        				"w":12,
+        				"x":12,
+        				"y":18
+        			},
+        			"id":92,
+        			"isNew":true,
+        			"legend":{
+        				"alignAsTable":false,
+        				"avg":false,
+        				"current":false,
+        				"max":false,
+        				"min":false,
+        				"rightSide":false,
+        				"show":false,
+        				"sideWidth":200,
+        				"sort":"current",
+        				"sortDesc":true,
+        				"total":false,
+        				"values":true
+        			},
+        			"lines":true,
+        			"linewidth":2,
+        			"links":[
+
+        			],
+        			"nullPointMode":"connected",
+        			"percentage":false,
+        			"pointradius":5,
+        			"points":false,
+        			"renderer":"flot",
+        			"seriesOverrides":[
+
+        			],
+        			"spaceLength":10,
+        			"stack":false,
+        			"steppedLine":true,
+        			"targets":[
+        				{
+        					"expr":"sum (container_memory_working_set_bytes{namespace=\"$namespace\"})\n/\nsum(node_memory_MemTotal_bytes)",
+        					"format":"time_series",
+        					"instant":false,
+        					"intervalFactor":1,
+        					"legendFormat":"mem utilization",
+        					"refId":"B"
+        				}
+        			],
+        			"thresholds":[
+
+        			],
+        			"timeFrom":"",
+        			"timeShift":null,
+        			"title":"Overall RAM Utilization",
+        			"tooltip":{
+        				"msResolution":false,
+        				"shared":true,
+        				"sort":2,
+        				"value_type":"cumulative"
+        			},
+        			"type":"graph",
+        			"xaxis":{
+        				"buckets":null,
+        				"mode":"time",
+        				"name":null,
+        				"show":true,
+        				"values":[
+
+        				]
+        			},
+        			"yaxes":[
+        				{
+        					"decimals":null,
+        					"format":"percent",
+        					"label":null,
+        					"logBase":1,
+        					"max":"110",
+        					"min":"0",
+        					"show":true
+        				},
+        				{
+        					"format":"short",
+        					"label":null,
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":false
+        				}
+        			],
+        			"yaxis":{
+        				"align":false,
+        				"alignLevel":null
+        			}
+        		},
+        		{
+        			"aliasColors":{
+
+        			},
+        			"bars":false,
+        			"dashLength":10,
+        			"dashes":false,
+        			"datasource":"${datasource}",
+        			"decimals":2,
+        			"description":"Traffic in and out of this namespace, as a sum of the pods within it",
+        			"editable":true,
+        			"error":false,
+        			"fill":1,
+        			"grid":{
+
+        			},
+        			"gridPos":{
+        				"h":6,
+        				"w":12,
+        				"x":0,
+        				"y":24
+        			},
+        			"height":"",
+        			"id":96,
+        			"isNew":true,
+        			"legend":{
+        				"alignAsTable":false,
+        				"avg":true,
+        				"current":true,
+        				"hideEmpty":false,
+        				"hideZero":false,
+        				"max":false,
+        				"min":false,
+        				"rightSide":false,
+        				"show":true,
+        				"sideWidth":null,
+        				"sort":"current",
+        				"sortDesc":true,
+        				"total":false,
+        				"values":true
+        			},
+        			"lines":true,
+        			"linewidth":2,
+        			"links":[
+
+        			],
+        			"nullPointMode":"connected",
+        			"percentage":false,
+        			"pointradius":5,
+        			"points":false,
+        			"renderer":"flot",
+        			"seriesOverrides":[
+
+        			],
+        			"spaceLength":10,
+        			"stack":false,
+        			"steppedLine":false,
+        			"targets":[
+        				{
+        					"expr":"sum (rate (container_network_receive_bytes_total{namespace=\"$namespace\"}[10m])) by (namespace)",
+        					"format":"time_series",
+        					"hide":false,
+        					"instant":false,
+        					"interval":"",
+        					"intervalFactor":1,
+        					"legendFormat":"<- in",
+        					"metric":"container_cpu",
+        					"refId":"A",
+        					"step":10
+        				},
+        				{
+        					"expr":"- sum (rate (container_network_transmit_bytes_total{namespace=\"$namespace\"}[10m])) by (namespace)",
+        					"format":"time_series",
+        					"hide":false,
+        					"instant":false,
+        					"interval":"",
+        					"intervalFactor":1,
+        					"legendFormat":"-> out",
+        					"refId":"B"
+        				}
+        			],
+        			"thresholds":[
+
+        			],
+        			"timeFrom":"",
+        			"timeShift":null,
+        			"title":"Network IO",
+        			"tooltip":{
+        				"msResolution":true,
+        				"shared":true,
+        				"sort":2,
+        				"value_type":"cumulative"
+        			},
+        			"type":"graph",
+        			"xaxis":{
+        				"buckets":null,
+        				"mode":"time",
+        				"name":null,
+        				"show":true,
+        				"values":[
+
+        				]
+        			},
+        			"yaxes":[
+        				{
+        					"format":"Bps",
+        					"label":"",
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":true
+        				},
+        				{
+        					"format":"short",
+        					"label":null,
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":false
+        				}
+        			],
+        			"yaxis":{
+        				"align":false,
+        				"alignLevel":null
+        			}
+        		},
+        		{
+        			"aliasColors":{
+
+        			},
+        			"bars":false,
+        			"dashLength":10,
+        			"dashes":false,
+        			"datasource":"${datasource}",
+        			"decimals":2,
+        			"description":"Disk reads and writes for the namespace, as a sum of the pods within it",
+        			"editable":true,
+        			"error":false,
+        			"fill":1,
+        			"grid":{
+
+        			},
+        			"gridPos":{
+        				"h":6,
+        				"w":12,
+        				"x":12,
+        				"y":24
+        			},
+        			"height":"",
+        			"id":98,
+        			"isNew":true,
+        			"legend":{
+        				"alignAsTable":false,
+        				"avg":true,
+        				"current":true,
+        				"hideEmpty":false,
+        				"hideZero":false,
+        				"max":false,
+        				"min":false,
+        				"rightSide":false,
+        				"show":true,
+        				"sideWidth":null,
+        				"sort":"current",
+        				"sortDesc":true,
+        				"total":false,
+        				"values":true
+        			},
+        			"lines":true,
+        			"linewidth":2,
+        			"links":[
+
+        			],
+        			"nullPointMode":"connected",
+        			"percentage":false,
+        			"pointradius":5,
+        			"points":false,
+        			"renderer":"flot",
+        			"seriesOverrides":[
+
+        			],
+        			"spaceLength":10,
+        			"stack":false,
+        			"steppedLine":false,
+        			"targets":[
+        				{
+        					"expr":"sum (rate (container_fs_writes_bytes_total{namespace=\"$namespace\"}[10m])) by (namespace)",
+        					"format":"time_series",
+        					"hide":false,
+        					"instant":false,
+        					"interval":"",
+        					"intervalFactor":1,
+        					"legendFormat":"<- write",
+        					"metric":"container_cpu",
+        					"refId":"A",
+        					"step":10
+        				},
+        				{
+        					"expr":"- sum (rate (container_fs_reads_bytes_total{namespace=\"$namespace\"}[10m])) by (namespace)",
+        					"format":"time_series",
+        					"hide":false,
+        					"instant":false,
+        					"interval":"",
+        					"intervalFactor":1,
+        					"legendFormat":"-> read",
+        					"refId":"B"
+        				}
+        			],
+        			"thresholds":[
+
+        			],
+        			"timeFrom":"",
+        			"timeShift":null,
+        			"title":"Disk IO",
+        			"tooltip":{
+        				"msResolution":true,
+        				"shared":true,
+        				"sort":2,
+        				"value_type":"cumulative"
+        			},
+        			"type":"graph",
+        			"xaxis":{
+        				"buckets":null,
+        				"mode":"time",
+        				"name":null,
+        				"show":true,
+        				"values":[
+
+        				]
+        			},
+        			"yaxes":[
+        				{
+        					"format":"Bps",
+        					"label":"",
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":true
+        				},
+        				{
+        					"format":"short",
+        					"label":null,
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":false
+        				}
+        			],
+        			"yaxis":{
+        				"align":false,
+        				"alignLevel":null
+        			}
+        		}
+        	],
+        	"refresh":"10s",
+        	"schemaVersion":16,
+        	"style":"dark",
+        	"tags":[
+        		"cost",
+        		"utilization",
+        		"metrics"
+        	],
+        	"templating":{
+        		"list":[
+        			{
+        				"current":{
+        					"text":"23.06",
+        					"value":"23.06"
+        				},
+        				"hide":0,
+        				"label":"CPU",
+        				"name":"costcpu",
+        				"options":[
+        					{
+        						"text":"23.06",
+        						"value":"23.06"
+        					}
+        				],
+        				"query":"23.06",
+        				"skipUrlSync":false,
+        				"type":"constant"
+        			},
+        			{
+        				"current":{
+        					"text":"7.28",
+        					"value":"7.28"
+        				},
+        				"hide":0,
+        				"label":"PE CPU",
+        				"name":"costpcpu",
+        				"options":[
+        					{
+        						"text":"7.28",
+        						"value":"7.28"
+        					}
+        				],
+        				"query":"7.28",
+        				"skipUrlSync":false,
+        				"type":"constant"
+        			},
+        			{
+        				"current":{
+        					"text":"3.25",
+        					"value":"3.25"
+        				},
+        				"hide":0,
+        				"label":"RAM",
+        				"name":"costram",
+        				"options":[
+        					{
+        						"text":"3.25",
+        						"value":"3.25"
+        					}
+        				],
+        				"query":"3.25",
+        				"skipUrlSync":false,
+        				"type":"constant"
+        			},
+        			{
+        				"current":{
+        					"text":"0.6862",
+        					"value":"0.6862"
+        				},
+        				"hide":0,
+        				"label":"PE RAM",
+        				"name":"costpram",
+        				"options":[
+        					{
+        						"text":"0.6862",
+        						"value":"0.6862"
+        					}
+        				],
+        				"query":"0.6862",
+        				"skipUrlSync":false,
+        				"type":"constant"
+        			},
+        			{
+        				"current":{
+        					"text":"0.04",
+        					"value":"0.04"
+        				},
+        				"hide":0,
+        				"label":"Storage",
+        				"name":"costStorageStandard",
+        				"options":[
+        					{
+        						"text":"0.04",
+        						"value":"0.04"
+        					}
+        				],
+        				"query":"0.04",
+        				"skipUrlSync":false,
+        				"type":"constant"
+        			},
+        			{
+        				"current":{
+        					"text":".17",
+        					"value":".17"
+        				},
+        				"hide":0,
+        				"label":"SSD",
+        				"name":"costStorageSSD",
+        				"options":[
+        					{
+        						"text":".17",
+        						"value":".17"
+        					}
+        				],
+        				"query":".17",
+        				"skipUrlSync":false,
+        				"type":"constant"
+        			},
+        			{
+        				"current":{
+        					"text":"30",
+        					"value":"30"
+        				},
+        				"hide":0,
+        				"label":"Disc.",
+        				"name":"costDiscount",
+        				"options":[
+        					{
+        						"text":"30",
+        						"value":"30"
+        					}
+        				],
+        				"query":"30",
+        				"skipUrlSync":false,
+        				"type":"constant"
+        			},
+        			{
+        				"allValue":null,
+        				"current":{
+        					"text":"kube-system",
+        					"value":"kube-system"
+        				},
+        				"datasource":"${datasource}",
+        				"hide":0,
+        				"includeAll":false,
+        				"label":"NS",
+        				"multi":false,
+        				"name":"namespace",
+        				"options":[
+
+        				],
+        				"query":"query_result(sum(kube_namespace_created{namespace!=\"\"}) by (namespace))",
+        				"refresh":1,
+        				"regex":"/namespace=\\\"(.*?)(\\\")/",
+        				"skipUrlSync":false,
+        				"sort":0,
+        				"tagValuesQuery":"",
+        				"tags":[
+
+        				],
+        				"tagsQuery":"",
+        				"type":"query",
+        				"useTags":false
+        			},
+        			{
+        				"datasource":"${datasource}",
+        				"filters":[
+
+        				],
+        				"hide":0,
+        				"label":"",
+        				"name":"Filters",
+        				"skipUrlSync":false,
+        				"type":"adhoc"
+        			},
+        			{
+        				"current": {
+        					"selected": true,
+        					"text": "default-kubecost",
+        					"value": "default-kubecost"
+        				},
+        				"error": null,
+        				"hide": 0,
+        				"includeAll": false,
+        				"label": null,
+        				"multi": false,
+        				"name": "datasource",
+        				"options": [],
+        				"query": "prometheus",
+        				"refresh": 1,
+        				"regex": "",
+        				"skipUrlSync": false,
+        				"type": "datasource"
+        			}
+        		]
+        	},
+        	"time":{
+        		"from":"now-15m",
+        		"to":"now"
+        	},
+        	"timepicker":{
+        		"hidden":false,
+        		"refresh_intervals":[
+        			"5s",
+        			"10s",
+        			"30s",
+        			"1m",
+        			"5m",
+        			"15m",
+        			"30m",
+        			"1h",
+        			"2h",
+        			"1d"
+        		],
+        		"time_options":[
+        			"5m",
+        			"15m",
+        			"1h",
+        			"6h",
+        			"12h",
+        			"24h",
+        			"2d",
+        			"7d",
+        			"30d"
+        		]
+        	},
+        	"timezone":"browser",
+        	"title":"Namespace utilization metrics",
+        	"uid":"at-cost-analysis-namespace2",
+        	"version":1
+        }
+---
+# Source: cost-analyzer/templates/grafana-dashboard-node-utilization-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-utilization-dashboard
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+    grafana_dashboard: "1"
+  annotations:
+    {}
+data:
+    node-utilization.json: |-
+        {
+        	"annotations":{
+        		"list":[
+        			{
+        				"builtIn":1,
+        				"datasource":"-- Grafana --",
+        				"enable":true,
+        				"hide":true,
+        				"iconColor":"rgba(0, 211, 255, 1)",
+        				"name":"Annotations & Alerts",
+        				"type":"dashboard"
+        			}
+        		]
+        	},
+        	"editable":true,
+        	"gnetId":null,
+        	"graphTooltip":0,
+        	"id":6,
+        	"iteration":1557245882378,
+        	"links":[
+
+        	],
+        	"panels":[
+        		{
+        			"cacheTimeout":null,
+        			"colorBackground":false,
+        			"colorValue":false,
+        			"colors":[
+        				"#299c46",
+        				"rgba(237, 129, 40, 0.89)",
+        				"#d44a3a"
+        			],
+        			"datasource":"${datasource}",
+        			"format":"percentunit",
+        			"gauge":{
+        				"maxValue":100,
+        				"minValue":0,
+        				"show":true,
+        				"thresholdLabels":false,
+        				"thresholdMarkers":true
+        			},
+        			"gridPos":{
+        				"h":7,
+        				"w":8,
+        				"x":0,
+        				"y":0
+        			},
+        			"id":2,
+        			"interval":null,
+        			"links":[
+
+        			],
+        			"mappingType":1,
+        			"mappingTypes":[
+        				{
+        					"name":"value to text",
+        					"value":1
+        				},
+        				{
+        					"name":"range to text",
+        					"value":2
+        				}
+        			],
+        			"maxDataPoints":100,
+        			"nullPointMode":"connected",
+        			"nullText":null,
+        			"postfix":"",
+        			"postfixFontSize":"50%",
+        			"prefix":"",
+        			"prefixFontSize":"50%",
+        			"rangeMaps":[
+        				{
+        					"from":"null",
+        					"text":"N/A",
+        					"to":"null"
+        				}
+        			],
+        			"sparkline":{
+        				"fillColor":"rgba(31, 118, 189, 0.18)",
+        				"full":false,
+        				"lineColor":"rgb(31, 120, 193)",
+        				"show":false
+        			},
+        			"tableColumn":"",
+        			"targets":[
+        				{
+        					"expr":"sum(irate(container_cpu_usage_seconds_total{id=\"/\",instance=\"$node\"}[10m]))",
+        					"format":"time_series",
+        					"intervalFactor":1,
+        					"refId":"A"
+        				}
+        			],
+        			"thresholds":"",
+        			"title":"CPU Usage",
+        			"type":"singlestat",
+        			"valueFontSize":"80%",
+        			"valueMaps":[
+        				{
+        					"op":"=",
+        					"text":"N/A",
+        					"value":"null"
+        				}
+        			],
+        			"valueName":"avg"
+        		},
+        		{
+        			"cacheTimeout":null,
+        			"colorBackground":false,
+        			"colorValue":false,
+        			"colors":[
+        				"#299c46",
+        				"rgba(237, 129, 40, 0.89)",
+        				"#d44a3a"
+        			],
+        			"datasource":"${datasource}",
+        			"format":"percentunit",
+        			"gauge":{
+        				"maxValue":100,
+        				"minValue":0,
+        				"show":true,
+        				"thresholdLabels":false,
+        				"thresholdMarkers":true
+        			},
+        			"gridPos":{
+        				"h":7,
+        				"w":8,
+        				"x":8,
+        				"y":0
+        			},
+        			"id":3,
+        			"interval":null,
+        			"links":[
+
+        			],
+        			"mappingType":1,
+        			"mappingTypes":[
+        				{
+        					"name":"value to text",
+        					"value":1
+        				},
+        				{
+        					"name":"range to text",
+        					"value":2
+        				}
+        			],
+        			"maxDataPoints":100,
+        			"nullPointMode":"connected",
+        			"nullText":null,
+        			"postfix":"",
+        			"postfixFontSize":"50%",
+        			"prefix":"",
+        			"prefixFontSize":"50%",
+        			"rangeMaps":[
+        				{
+        					"from":"null",
+        					"text":"N/A",
+        					"to":"null"
+        				}
+        			],
+        			"sparkline":{
+        				"fillColor":"rgba(31, 118, 189, 0.18)",
+        				"full":false,
+        				"lineColor":"rgb(31, 120, 193)",
+        				"show":false
+        			},
+        			"tableColumn":"",
+        			"targets":[
+        				{
+        					"expr":"SUM(container_memory_usage_bytes{namespace!=\"\",instance=\"$node\"}) / SUM(kube_node_status_capacity{resource=\"memory\", unit=\"byte\", node=\"$node\"})",
+        					"format":"time_series",
+        					"intervalFactor":1,
+        					"refId":"A"
+        				}
+        			],
+        			"thresholds":"",
+        			"title":"Memory Usage",
+        			"type":"singlestat",
+        			"valueFontSize":"80%",
+        			"valueMaps":[
+        				{
+        					"op":"=",
+        					"text":"N/A",
+        					"value":"null"
+        				}
+        			],
+        			"valueName":"avg"
+        		},
+        		{
+        			"cacheTimeout":null,
+        			"colorBackground":false,
+        			"colorValue":false,
+        			"colors":[
+        				"#299c46",
+        				"rgba(237, 129, 40, 0.89)",
+        				"#d44a3a"
+        			],
+        			"datasource":"${datasource}",
+        			"format":"percentunit",
+        			"gauge":{
+        				"maxValue":100,
+        				"minValue":0,
+        				"show":true,
+        				"thresholdLabels":false,
+        				"thresholdMarkers":true
+        			},
+        			"gridPos":{
+        				"h":7,
+        				"w":8,
+        				"x":16,
+        				"y":0
+        			},
+        			"id":4,
+        			"interval":null,
+        			"links":[
+
+        			],
+        			"mappingType":1,
+        			"mappingTypes":[
+        				{
+        					"name":"value to text",
+        					"value":1
+        				},
+        				{
+        					"name":"range to text",
+        					"value":2
+        				}
+        			],
+        			"maxDataPoints":100,
+        			"nullPointMode":"connected",
+        			"nullText":null,
+        			"postfix":"",
+        			"postfixFontSize":"50%",
+        			"prefix":"",
+        			"prefixFontSize":"50%",
+        			"rangeMaps":[
+        				{
+        					"from":"null",
+        					"text":"N/A",
+        					"to":"null"
+        				}
+        			],
+        			"sparkline":{
+        				"fillColor":"rgba(31, 118, 189, 0.18)",
+        				"full":false,
+        				"lineColor":"rgb(31, 120, 193)",
+        				"show":false
+        			},
+        			"tableColumn":"",
+        			"targets":[
+        				{
+        					"expr":"sum(container_fs_usage_bytes{device=~\"^/dev/[sv]d[a-z][1-9]$\",id=\"/\",instance=\"$node\"}) /\nsum(container_fs_limit_bytes{device=~\"^/dev/[sv]d[a-z][1-9]$\",id=\"/\",instance=\"$node\"})",
+        					"format":"time_series",
+        					"intervalFactor":1,
+        					"refId":"A"
+        				}
+        			],
+        			"thresholds":"",
+        			"title":"Storage Usage",
+        			"type":"singlestat",
+        			"valueFontSize":"80%",
+        			"valueMaps":[
+        				{
+        					"op":"=",
+        					"text":"N/A",
+        					"value":"null"
+        				}
+        			],
+        			"valueName":"avg"
+        		},
+        		{
+        			"columns":[
+        				{
+        					"text":"Avg",
+        					"value":"avg"
+        				}
+        			],
+        			"datasource":"${datasource}",
+        			"fontSize":"100%",
+        			"gridPos":{
+        				"h":8,
+        				"w":16,
+        				"x":0,
+        				"y":7
+        			},
+        			"hideTimeOverride":true,
+        			"id":21,
+        			"links":[
+
+        			],
+        			"pageSize":8,
+        			"repeat":null,
+        			"repeatDirection":"v",
+        			"scroll":true,
+        			"showHeader":true,
+        			"sort":{
+        				"col":4,
+        				"desc":true
+        			},
+        			"styles":[
+        				{
+        					"alias":"Pod",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(50, 172, 45, 0.97)",
+        						"#c15c17"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"link":false,
+        					"linkTooltip":"",
+        					"linkUrl":"",
+        					"pattern":"pod_name",
+        					"thresholds":[
+        						"30",
+        						"80"
+        					],
+        					"type":"string",
+        					"unit":"currencyUSD"
+        				},
+        				{
+        					"alias":"",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Time",
+        					"thresholds":[
+
+        					],
+        					"type":"hidden",
+        					"unit":"short"
+        				},
+        				{
+        					"alias":"CPU Usage",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #C",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"short"
+        				},
+        				{
+        					"alias":"CPU Request",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #A",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"short"
+        				},
+        				{
+        					"alias":"CPU Limit",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #B",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"short"
+        				},
+        				{
+        					"alias":"Mem Usage",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #D",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"bytes"
+        				},
+        				{
+        					"alias":"Mem Request",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #E",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"bytes"
+        				},
+        				{
+        					"alias":"Mem Limit",
+        					"colorMode":null,
+        					"colors":[
+        						"rgba(245, 54, 54, 0.9)",
+        						"rgba(237, 129, 40, 0.89)",
+        						"rgba(50, 172, 45, 0.97)"
+        					],
+        					"dateFormat":"YYYY-MM-DD HH:mm:ss",
+        					"decimals":2,
+        					"mappingType":1,
+        					"pattern":"Value #F",
+        					"thresholds":[
+
+        					],
+        					"type":"number",
+        					"unit":"bytes"
+        				}
+        			],
+        			"targets":[
+        				{
+        					"expr":"sum(rate(container_cpu_usage_seconds_total{container_name!=\"\",container_name!=\"POD\",pod_name!=\"\",instance=\"$node\"}[24h])) by (pod_name)",
+        					"format":"table",
+        					"instant":true,
+        					"intervalFactor":1,
+        					"refId":"C"
+        				},
+        				{
+        					"expr":"sum(label_replace(\nsum(avg_over_time(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod), \n\"pod_name\",\"$1\",\"pod\",\"(.+)\")\nor up * 0\n) by (pod_name)",
+        					"format":"table",
+        					"instant":true,
+        					"intervalFactor":1,
+        					"refId":"A"
+        				},
+        				{
+        					"expr":"sum(avg_over_time(container_memory_usage_bytes{container_name!=\"\",container_name!=\"POD\",pod_name!=\"\",instance=\"$node\"}[24h])) by (pod_name)\n",
+        					"format":"table",
+        					"instant":true,
+        					"intervalFactor":1,
+        					"refId":"D"
+        				},
+        				{
+        					"expr":"sum(label_replace(label_replace(\nsum(avg_over_time(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod),\n\"container_name\",\"$1\",\"container\",\"(.+)\"), \"pod_name\",\"$1\",\"pod\",\"(.+)\")\nor up * 0\n) by (pod_name)\n",
+        					"format":"table",
+        					"instant":true,
+        					"intervalFactor":1,
+        					"refId":"E"
+        				}
+        			],
+        			"timeFrom":"1M",
+        			"timeShift":null,
+        			"title":"Current pods",
+        			"transform":"table",
+        			"transparent":false,
+        			"type":"table"
+        		},
+        		{
+        			"cacheTimeout":null,
+        			"colorBackground":false,
+        			"colorValue":false,
+        			"colors":[
+        				"#299c46",
+        				"rgba(237, 129, 40, 0.89)",
+        				"#d44a3a"
+        			],
+        			"datasource":"${datasource}",
+        			"decimals":0,
+        			"format":"none",
+        			"gauge":{
+        				"maxValue":100,
+        				"minValue":0,
+        				"show":false,
+        				"thresholdLabels":false,
+        				"thresholdMarkers":true
+        			},
+        			"gridPos":{
+        				"h":4,
+        				"w":4,
+        				"x":16,
+        				"y":7
+        			},
+        			"id":8,
+        			"interval":null,
+        			"links":[
+
+        			],
+        			"mappingType":1,
+        			"mappingTypes":[
+        				{
+        					"name":"value to text",
+        					"value":1
+        				},
+        				{
+        					"name":"range to text",
+        					"value":2
+        				}
+        			],
+        			"maxDataPoints":100,
+        			"nullPointMode":"connected",
+        			"nullText":null,
+        			"postfix":"",
+        			"postfixFontSize":"50%",
+        			"prefix":"",
+        			"prefixFontSize":"50%",
+        			"rangeMaps":[
+        				{
+        					"from":"null",
+        					"text":"N/A",
+        					"to":"null"
+        				}
+        			],
+        			"sparkline":{
+        				"fillColor":"rgba(31, 118, 189, 0.18)",
+        				"full":false,
+        				"lineColor":"rgb(31, 120, 193)",
+        				"show":false
+        			},
+        			"tableColumn":"",
+        			"targets":[
+        				{
+        					"expr":"sum(\n count(avg_over_time(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", container!=\"\",container!=\"POD\",node=\"$node\"}[24h])) by (pod)\n * on (pod) group_right()\n sum(kube_pod_container_status_running) by (pod)\n)",
+        					"format":"time_series",
+        					"instant":true,
+        					"intervalFactor":1,
+        					"refId":"A"
+        				}
+        			],
+        			"thresholds":"",
+        			"title":"Pods Running",
+        			"type":"singlestat",
+        			"valueFontSize":"80%",
+        			"valueMaps":[
+        				{
+        					"op":"=",
+        					"text":"N/A",
+        					"value":"null"
+        				}
+        			],
+        			"valueName":"current"
+        		},
+        		{
+        			"cacheTimeout":null,
+        			"colorBackground":false,
+        			"colorValue":false,
+        			"colors":[
+        				"#299c46",
+        				"rgba(237, 129, 40, 0.89)",
+        				"#d44a3a"
+        			],
+        			"datasource":"${datasource}",
+        			"format":"bytes",
+        			"gauge":{
+        				"maxValue":100,
+        				"minValue":0,
+        				"show":false,
+        				"thresholdLabels":false,
+        				"thresholdMarkers":true
+        			},
+        			"gridPos":{
+        				"h":4,
+        				"w":4,
+        				"x":20,
+        				"y":7
+        			},
+        			"id":18,
+        			"interval":null,
+        			"links":[
+
+        			],
+        			"mappingType":1,
+        			"mappingTypes":[
+        				{
+        					"name":"value to text",
+        					"value":1
+        				},
+        				{
+        					"name":"range to text",
+        					"value":2
+        				}
+        			],
+        			"maxDataPoints":100,
+        			"nullPointMode":"connected",
+        			"nullText":null,
+        			"postfix":"",
+        			"postfixFontSize":"50%",
+        			"prefix":"",
+        			"prefixFontSize":"50%",
+        			"rangeMaps":[
+        				{
+        					"from":"null",
+        					"text":"N/A",
+        					"to":"null"
+        				}
+        			],
+        			"sparkline":{
+        				"fillColor":"rgba(31, 118, 189, 0.18)",
+        				"full":false,
+        				"lineColor":"rgb(31, 120, 193)",
+        				"show":false
+        			},
+        			"tableColumn":"",
+        			"targets":[
+        				{
+        					"expr":"sum(container_fs_limit_bytes{device=~\"^/dev/[sv]d[a-z][1-9]$\",id=\"/\",instance=\"$node\"})",
+        					"format":"time_series",
+        					"intervalFactor":1,
+        					"refId":"A"
+        				}
+        			],
+        			"thresholds":"",
+        			"title":"Storage Capacity",
+        			"type":"singlestat",
+        			"valueFontSize":"80%",
+        			"valueMaps":[
+        				{
+        					"op":"=",
+        					"text":"N/A",
+        					"value":"null"
+        				}
+        			],
+        			"valueName":"current"
+        		},
+        		{
+        			"cacheTimeout":null,
+        			"colorBackground":false,
+        			"colorValue":false,
+        			"colors":[
+        				"#299c46",
+        				"rgba(237, 129, 40, 0.89)",
+        				"#d44a3a"
+        			],
+        			"datasource":"${datasource}",
+        			"format":"none",
+        			"gauge":{
+        				"maxValue":100,
+        				"minValue":0,
+        				"show":false,
+        				"thresholdLabels":false,
+        				"thresholdMarkers":true
+        			},
+        			"gridPos":{
+        				"h":4,
+        				"w":4,
+        				"x":16,
+        				"y":11
+        			},
+        			"id":9,
+        			"interval":null,
+        			"links":[
+
+        			],
+        			"mappingType":1,
+        			"mappingTypes":[
+        				{
+        					"name":"value to text",
+        					"value":1
+        				},
+        				{
+        					"name":"range to text",
+        					"value":2
+        				}
+        			],
+        			"maxDataPoints":100,
+        			"nullPointMode":"connected",
+        			"nullText":null,
+        			"postfix":"",
+        			"postfixFontSize":"50%",
+        			"prefix":"",
+        			"prefixFontSize":"50%",
+        			"rangeMaps":[
+        				{
+        					"from":"null",
+        					"text":"N/A",
+        					"to":"null"
+        				}
+        			],
+        			"sparkline":{
+        				"fillColor":"rgba(31, 118, 189, 0.18)",
+        				"full":false,
+        				"lineColor":"rgb(31, 120, 193)",
+        				"show":false
+        			},
+        			"tableColumn":"",
+        			"targets":[
+        				{
+        					"expr":"kube_node_status_capacity{resource=\"cpu\", unit=\"core\", node=\"$node\"}",
+        					"format":"time_series",
+        					"intervalFactor":1,
+        					"refId":"A"
+        				}
+        			],
+        			"thresholds":"",
+        			"title":"CPU Capacity",
+        			"type":"singlestat",
+        			"valueFontSize":"80%",
+        			"valueMaps":[
+        				{
+        					"op":"=",
+        					"text":"N/A",
+        					"value":"null"
+        				}
+        			],
+        			"valueName":"avg"
+        		},
+        		{
+        			"cacheTimeout":null,
+        			"colorBackground":false,
+        			"colorValue":false,
+        			"colors":[
+        				"#299c46",
+        				"rgba(237, 129, 40, 0.89)",
+        				"#d44a3a"
+        			],
+        			"datasource":"${datasource}",
+        			"format":"bytes",
+        			"gauge":{
+        				"maxValue":100,
+        				"minValue":0,
+        				"show":false,
+        				"thresholdLabels":false,
+        				"thresholdMarkers":true
+        			},
+        			"gridPos":{
+        				"h":4,
+        				"w":4,
+        				"x":20,
+        				"y":11
+        			},
+        			"id":19,
+        			"interval":null,
+        			"links":[
+
+        			],
+        			"mappingType":1,
+        			"mappingTypes":[
+        				{
+        					"name":"value to text",
+        					"value":1
+        				},
+        				{
+        					"name":"range to text",
+        					"value":2
+        				}
+        			],
+        			"maxDataPoints":100,
+        			"nullPointMode":"connected",
+        			"nullText":null,
+        			"postfix":"",
+        			"postfixFontSize":"50%",
+        			"prefix":"",
+        			"prefixFontSize":"50%",
+        			"rangeMaps":[
+        				{
+        					"from":"null",
+        					"text":"N/A",
+        					"to":"null"
+        				}
+        			],
+        			"sparkline":{
+        				"fillColor":"rgba(31, 118, 189, 0.18)",
+        				"full":false,
+        				"lineColor":"rgb(31, 120, 193)",
+        				"show":false
+        			},
+        			"tableColumn":"",
+        			"targets":[
+        				{
+        					"expr":"kube_node_status_capacity{resource=\"memory\", unit=\"byte\", node=\"$node\"}",
+        					"format":"time_series",
+        					"intervalFactor":1,
+        					"refId":"A"
+        				}
+        			],
+        			"thresholds":"",
+        			"title":"RAM Capacity",
+        			"type":"singlestat",
+        			"valueFontSize":"80%",
+        			"valueMaps":[
+        				{
+        					"op":"=",
+        					"text":"N/A",
+        					"value":"null"
+        				}
+        			],
+        			"valueName":"current"
+        		},
+        		{
+        			"aliasColors":{
+
+        			},
+        			"bars":false,
+        			"dashLength":10,
+        			"dashes":false,
+        			"datasource":"${datasource}",
+        			"decimals":3,
+        			"description":"This panel shows historical utilization for the node.",
+        			"editable":true,
+        			"error":false,
+        			"fill":0,
+        			"grid":{
+
+        			},
+        			"gridPos":{
+        				"h":6,
+        				"w":12,
+        				"x":0,
+        				"y":15
+        			},
+        			"height":"",
+        			"id":11,
+        			"isNew":true,
+        			"legend":{
+        				"alignAsTable":false,
+        				"avg":false,
+        				"current":false,
+        				"hideEmpty":false,
+        				"hideZero":false,
+        				"max":false,
+        				"min":false,
+        				"rightSide":false,
+        				"show":false,
+        				"sideWidth":null,
+        				"sort":"current",
+        				"sortDesc":true,
+        				"total":false,
+        				"values":true
+        			},
+        			"lines":true,
+        			"linewidth":2,
+        			"links":[
+
+        			],
+        			"nullPointMode":"connected",
+        			"percentage":false,
+        			"pointradius":5,
+        			"points":false,
+        			"renderer":"flot",
+        			"seriesOverrides":[
+
+        			],
+        			"spaceLength":10,
+        			"stack":false,
+        			"steppedLine":true,
+        			"targets":[
+        				{
+        					"expr":"sum(irate(container_cpu_usage_seconds_total{id=\"/\",instance=\"$node\"}[10m]))",
+        					"format":"time_series",
+        					"hide":false,
+        					"instant":false,
+        					"interval":"10s",
+        					"intervalFactor":1,
+        					"legendFormat":"cpu utilization",
+        					"metric":"container_cpu",
+        					"refId":"A",
+        					"step":10
+        				}
+        			],
+        			"thresholds":[
+
+        			],
+        			"timeFrom":"",
+        			"timeShift":null,
+        			"title":"CPU Utilization",
+        			"tooltip":{
+        				"msResolution":true,
+        				"shared":true,
+        				"sort":2,
+        				"value_type":"cumulative"
+        			},
+        			"type":"graph",
+        			"xaxis":{
+        				"buckets":null,
+        				"mode":"time",
+        				"name":null,
+        				"show":true,
+        				"values":[
+
+        				]
+        			},
+        			"yaxes":[
+        				{
+        					"decimals":null,
+        					"format":"percentunit",
+        					"label":"",
+        					"logBase":1,
+        					"max":"1.1",
+        					"min":"0",
+        					"show":true
+        				},
+        				{
+        					"format":"short",
+        					"label":null,
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":false
+        				}
+        			],
+        			"yaxis":{
+        				"align":false,
+        				"alignLevel":null
+        			}
+        		},
+        		{
+        			"aliasColors":{
+
+        			},
+        			"bars":false,
+        			"dashLength":10,
+        			"dashes":false,
+        			"datasource":"${datasource}",
+        			"decimals":2,
+        			"description":"This panel shows historical utilization for the node.",
+        			"editable":true,
+        			"error":false,
+        			"fill":0,
+        			"grid":{
+
+        			},
+        			"gridPos":{
+        				"h":6,
+        				"w":12,
+        				"x":12,
+        				"y":15
+        			},
+        			"id":13,
+        			"isNew":true,
+        			"legend":{
+        				"alignAsTable":false,
+        				"avg":false,
+        				"current":false,
+        				"max":false,
+        				"min":false,
+        				"rightSide":false,
+        				"show":false,
+        				"sideWidth":200,
+        				"sort":"current",
+        				"sortDesc":true,
+        				"total":false,
+        				"values":true
+        			},
+        			"lines":true,
+        			"linewidth":2,
+        			"links":[
+
+        			],
+        			"nullPointMode":"connected",
+        			"percentage":false,
+        			"pointradius":5,
+        			"points":false,
+        			"renderer":"flot",
+        			"seriesOverrides":[
+
+        			],
+        			"spaceLength":10,
+        			"stack":false,
+        			"steppedLine":true,
+        			"targets":[
+        				{
+        					"expr":"SUM(container_memory_usage_bytes{namespace!=\"\",instance=\"$node\"}) / SUM(kube_node_status_capacity{resource=\"memory\", unit=\"byte\", node=\"$node\"})",
+        					"format":"time_series",
+        					"instant":false,
+        					"interval":"10s",
+        					"intervalFactor":1,
+        					"legendFormat":"ram utilization",
+        					"metric":"container_memory_usage:sort_desc",
+        					"refId":"A",
+        					"step":10
+        				}
+        			],
+        			"thresholds":[
+
+        			],
+        			"timeFrom":"",
+        			"timeShift":null,
+        			"title":"RAM Utilization",
+        			"tooltip":{
+        				"msResolution":false,
+        				"shared":true,
+        				"sort":2,
+        				"value_type":"cumulative"
+        			},
+        			"type":"graph",
+        			"xaxis":{
+        				"buckets":null,
+        				"mode":"time",
+        				"name":null,
+        				"show":true,
+        				"values":[
+
+        				]
+        			},
+        			"yaxes":[
+        				{
+        					"decimals":null,
+        					"format":"percentunit",
+        					"label":null,
+        					"logBase":1,
+        					"max":"1.1",
+        					"min":"0",
+        					"show":true
+        				},
+        				{
+        					"format":"short",
+        					"label":null,
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":false
+        				}
+        			],
+        			"yaxis":{
+        				"align":false,
+        				"alignLevel":null
+        			}
+        		},
+        		{
+        			"aliasColors":{
+
+        			},
+        			"bars":false,
+        			"dashLength":10,
+        			"dashes":false,
+        			"datasource":"${datasource}",
+        			"decimals":2,
+        			"description":"Traffic in and out of this namespace, as a sum of the pods within it",
+        			"editable":true,
+        			"error":false,
+        			"fill":1,
+        			"grid":{
+
+        			},
+        			"gridPos":{
+        				"h":6,
+        				"w":12,
+        				"x":0,
+        				"y":21
+        			},
+        			"height":"",
+        			"id":15,
+        			"isNew":true,
+        			"legend":{
+        				"alignAsTable":false,
+        				"avg":true,
+        				"current":true,
+        				"hideEmpty":false,
+        				"hideZero":false,
+        				"max":false,
+        				"min":false,
+        				"rightSide":false,
+        				"show":true,
+        				"sideWidth":null,
+        				"sort":"current",
+        				"sortDesc":true,
+        				"total":false,
+        				"values":true
+        			},
+        			"lines":true,
+        			"linewidth":2,
+        			"links":[
+
+        			],
+        			"nullPointMode":"connected",
+        			"percentage":false,
+        			"pointradius":5,
+        			"points":false,
+        			"renderer":"flot",
+        			"seriesOverrides":[
+
+        			],
+        			"spaceLength":10,
+        			"stack":false,
+        			"steppedLine":false,
+        			"targets":[
+        				{
+        					"expr":"sum (rate (container_network_receive_bytes_total{instance=\"$node\"}[10m]))",
+        					"format":"time_series",
+        					"hide":false,
+        					"instant":false,
+        					"interval":"",
+        					"intervalFactor":1,
+        					"legendFormat":"<- in",
+        					"metric":"container_cpu",
+        					"refId":"A",
+        					"step":10
+        				},
+        				{
+        					"expr":"- sum (rate (container_network_transmit_bytes_total{instance=\"$node\"}[10m]))",
+        					"format":"time_series",
+        					"hide":false,
+        					"instant":false,
+        					"interval":"",
+        					"intervalFactor":1,
+        					"legendFormat":"-> out",
+        					"refId":"B"
+        				}
+        			],
+        			"thresholds":[
+
+        			],
+        			"timeFrom":"",
+        			"timeShift":null,
+        			"title":"Network IO",
+        			"tooltip":{
+        				"msResolution":true,
+        				"shared":true,
+        				"sort":2,
+        				"value_type":"cumulative"
+        			},
+        			"type":"graph",
+        			"xaxis":{
+        				"buckets":null,
+        				"mode":"time",
+        				"name":null,
+        				"show":true,
+        				"values":[
+
+        				]
+        			},
+        			"yaxes":[
+        				{
+        					"format":"Bps",
+        					"label":"",
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":true
+        				},
+        				{
+        					"format":"short",
+        					"label":null,
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":false
+        				}
+        			],
+        			"yaxis":{
+        				"align":false,
+        				"alignLevel":null
+        			}
+        		},
+        		{
+        			"aliasColors":{
+
+        			},
+        			"bars":false,
+        			"dashLength":10,
+        			"dashes":false,
+        			"datasource":"${datasource}",
+        			"decimals":2,
+        			"description":"Disk reads and writes for the namespace, as a sum of the pods within it",
+        			"editable":true,
+        			"error":false,
+        			"fill":1,
+        			"grid":{
+
+        			},
+        			"gridPos":{
+        				"h":6,
+        				"w":12,
+        				"x":12,
+        				"y":21
+        			},
+        			"height":"",
+        			"id":17,
+        			"isNew":true,
+        			"legend":{
+        				"alignAsTable":false,
+        				"avg":true,
+        				"current":true,
+        				"hideEmpty":false,
+        				"hideZero":false,
+        				"max":false,
+        				"min":false,
+        				"rightSide":false,
+        				"show":true,
+        				"sideWidth":null,
+        				"sort":"current",
+        				"sortDesc":true,
+        				"total":false,
+        				"values":true
+        			},
+        			"lines":true,
+        			"linewidth":2,
+        			"links":[
+
+        			],
+        			"nullPointMode":"connected",
+        			"percentage":false,
+        			"pointradius":5,
+        			"points":false,
+        			"renderer":"flot",
+        			"seriesOverrides":[
+
+        			],
+        			"spaceLength":10,
+        			"stack":false,
+        			"steppedLine":false,
+        			"targets":[
+        				{
+        					"expr":"sum (rate (container_fs_writes_bytes_total{instance=\"$node\"}[10m]))",
+        					"format":"time_series",
+        					"hide":false,
+        					"instant":false,
+        					"interval":"",
+        					"intervalFactor":1,
+        					"legendFormat":"<- write",
+        					"metric":"container_cpu",
+        					"refId":"A",
+        					"step":10
+        				},
+        				{
+        					"expr":"- sum (rate (container_fs_reads_bytes_total{instance=\"$node\"}[10m]))",
+        					"format":"time_series",
+        					"hide":false,
+        					"instant":false,
+        					"interval":"",
+        					"intervalFactor":1,
+        					"legendFormat":"-> read",
+        					"refId":"B"
+        				}
+        			],
+        			"thresholds":[
+
+        			],
+        			"timeFrom":"",
+        			"timeShift":null,
+        			"title":"Disk IO",
+        			"tooltip":{
+        				"msResolution":true,
+        				"shared":true,
+        				"sort":2,
+        				"value_type":"cumulative"
+        			},
+        			"type":"graph",
+        			"xaxis":{
+        				"buckets":null,
+        				"mode":"time",
+        				"name":null,
+        				"show":true,
+        				"values":[
+
+        				]
+        			},
+        			"yaxes":[
+        				{
+        					"format":"Bps",
+        					"label":"",
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":true
+        				},
+        				{
+        					"format":"short",
+        					"label":null,
+        					"logBase":1,
+        					"max":null,
+        					"min":null,
+        					"show":false
+        				}
+        			],
+        			"yaxis":{
+        				"align":false,
+        				"alignLevel":null
+        			}
+        		}
+        	],
+        	"schemaVersion":16,
+        	"style":"dark",
+        	"tags":[
+        		"cost",
+        		"utilization",
+        		"metrics"
+        	],
+        	"templating":{
+        		"list":[
+        			{
+        				"allValue":null,
+        				"current":{
+        					"text":"ip-172-20-44-170.us-east-2.compute.internal",
+        					"value":"ip-172-20-44-170.us-east-2.compute.internal"
+        				},
+        				"datasource":"${datasource}",
+        				"hide":0,
+        				"includeAll":false,
+        				"label":null,
+        				"multi":false,
+        				"name":"node",
+        				"options":[
+
+        				],
+        				"query":"query_result(kube_node_labels)",
+        				"refresh":1,
+        				"regex":"/node=\\\"(.*?)(\\\")/",
+        				"skipUrlSync":false,
+        				"sort":0,
+        				"tagValuesQuery":"",
+        				"tags":[
+
+        				],
+        				"tagsQuery":"",
+        				"type":"query",
+        				"useTags":false
+        			},
+        			{
+        				"current": {
+        					"selected": true,
+        					"text": "default-kubecost",
+        					"value": "default-kubecost"
+        				},
+        				"error": null,
+        				"hide": 0,
+        				"includeAll": false,
+        				"label": null,
+        				"multi": false,
+        				"name": "datasource",
+        				"options": [],
+        				"query": "prometheus",
+        				"refresh": 1,
+        				"regex": "",
+        				"skipUrlSync": false,
+        				"type": "datasource"
+        			}
+        		]
+        	},
+        	"time":{
+        		"from":"now-6h",
+        		"to":"now"
+        	},
+        	"timepicker":{
+        		"refresh_intervals":[
+        			"5s",
+        			"10s",
+        			"30s",
+        			"1m",
+        			"5m",
+        			"15m",
+        			"30m",
+        			"1h",
+        			"2h",
+        			"1d"
+        		],
+        		"time_options":[
+        			"5m",
+        			"15m",
+        			"1h",
+        			"6h",
+        			"12h",
+        			"24h",
+        			"2d",
+        			"7d",
+        			"30d"
+        		]
+        	},
+        	"timezone":"",
+        	"title":"Node utilization metrics",
+        	"uid":"NUQW37Lmk",
+        	"version":1
+        }
+---
+# Source: cost-analyzer/templates/grafana-dashboard-pod-utilization-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-utilization-dashboard
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+    grafana_dashboard: "1"
+  annotations:
+    {}
+data:
+    pod-utilization.json: |-
+        {
+          "annotations": {
+            "list": [
+              {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+              }
+            ]
+          },
+          "description": "Visualize your kubernetes costs at the pod level.",
+          "editable": true,
+          "gnetId": 9063,
+          "graphTooltip": 0,
+          "iteration": 1616382275479,
+          "links": [],
+          "panels": [
+            {
+              "columns": [
+                {
+                  "text": "Avg",
+                  "value": "avg"
+                }
+              ],
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {}
+                },
+                "overrides": []
+              },
+              "fontSize": "100%",
+              "gridPos": {
+                "h": 5,
+                "w": 24,
+                "x": 0,
+                "y": 0
+              },
+              "hideTimeOverride": true,
+              "id": 98,
+              "links": [],
+              "pageSize": 5,
+              "repeatDirection": "v",
+              "scroll": true,
+              "showHeader": true,
+              "sort": {
+                "col": 6,
+                "desc": true
+              },
+              "styles": [
+                {
+                  "alias": "Container",
+                  "align": "auto",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(50, 172, 45, 0.97)",
+                    "#c15c17"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "link": false,
+                  "pattern": "container_name",
+                  "thresholds": [
+                    "30",
+                    "80"
+                  ],
+                  "type": "string",
+                  "unit": "currencyUSD"
+                },
+                {
+                  "alias": "Memory Allocation",
+                  "align": "auto",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "Value #B",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "bytes"
+                },
+                {
+                  "alias": "CPU Allocation",
+                  "align": "auto",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value #A",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "none"
+                },
+                {
+                  "alias": "",
+                  "align": "auto",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Time",
+                  "thresholds": [],
+                  "type": "hidden",
+                  "unit": "short"
+                },
+                {
+                  "alias": "Memory ($/hour)",
+                  "align": "auto",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value #C",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "currencyUSD"
+                },
+                {
+                  "alias": "Spot/PE RAM",
+                  "align": "auto",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value #D",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "currencyUSD"
+                },
+                {
+                  "alias": "Total",
+                  "align": "auto",
+                  "colorMode": null,
+                  "colors": [
+                    "#bf1b00",
+                    "rgba(50, 172, 45, 0.97)",
+                    "#ef843c"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value #E",
+                  "thresholds": [
+                    ""
+                  ],
+                  "type": "number",
+                  "unit": "currencyUSD"
+                }
+              ],
+              "targets": [
+                {
+                  "expr": "sum(\n  avg_over_time(container_memory_allocation_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\"}[$__range])\n) by (container,node)",
+                  "format": "table",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "refId": "B"
+                },
+                {
+                  "expr": "sum(\n  avg_over_time(container_cpu_allocation{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\"}[$__range])\n  or up * 0 \n) by (container,node)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "",
+                  "refId": "A"
+                }
+              ],
+              "timeFrom": "1M",
+              "timeShift": null,
+              "title": "Container cost  & allocation analysis",
+              "transform": "table",
+              "type": "table-old"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 3,
+              "description": "This graph attempts to show you CPU use of your application vs its requests",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {}
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 5
+              },
+              "height": "",
+              "hiddenSeries": false,
+              "id": 94,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": true,
+              "targets": [
+                {
+                  "expr": "avg (rate (container_cpu_usage_seconds_total{namespace=~\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\",container_name!=\"\"}[10m])) by (container_name)",
+                  "format": "time_series",
+                  "hide": false,
+                  "instant": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ container_name }} (usage)",
+                  "metric": "container_cpu",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "exemplar": true,
+                  "expr": "avg(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", namespace=~\"$namespace\", pod=~\"$pod\", container!=\"POD\"}) by (container)",
+                  "legendFormat": "{{ container}} (request)",
+                  "refId": "B"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": "",
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "CPU Usage vs Requested",
+              "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "none",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 3,
+              "description": "This graph attempts to show you RAM use of your application vs its requests",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {}
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 5
+              },
+              "height": "",
+              "hiddenSeries": false,
+              "id": 96,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": true,
+              "targets": [
+                {
+                  "expr": "avg (avg_over_time (container_memory_working_set_bytes{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\",container_name!=\"\"}[1m])) by (container_name)",
+                  "format": "time_series",
+                  "hide": false,
+                  "instant": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ container_name }} (usage)",
+                  "metric": "container_cpu",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "avg(kube_pod_container_resource_requests_memory_bytes{namespace=~\"$namespace\", pod=\"$pod\", container!=\"POD\"}) by (container)",
+                  "format": "time_series",
+                  "hide": false,
+                  "instant": false,
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ container }} (requested)",
+                  "refId": "B"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": "",
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "RAM Usage vs Requested",
+              "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "description": "Traffic in and out of this pod, as a sum of its containers",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {}
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 12
+              },
+              "height": "",
+              "hiddenSeries": false,
+              "id": 95,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": false,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg (rate (container_network_receive_bytes_total{namespace=\"$namespace\",pod_name=\"$pod\"}[10m])) by (pod_name)",
+                  "format": "time_series",
+                  "hide": false,
+                  "instant": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "<- in",
+                  "metric": "container_cpu",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "- avg (rate (container_network_transmit_bytes_total{namespace=\"$namespace\",pod_name=\"$pod\"}[10m])) by (pod_name)",
+                  "format": "time_series",
+                  "hide": false,
+                  "instant": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "-> out",
+                  "refId": "B"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": "",
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Network IO",
+              "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "Bps",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "description": "Disk read writes",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {}
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 12
+              },
+              "height": "",
+              "hiddenSeries": false,
+              "id": 97,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": false,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "avg (rate (container_fs_writes_bytes_total{namespace=\"$namespace\",pod_name=\"$pod\"}[10m])) by (pod_name)",
+                  "format": "time_series",
+                  "hide": false,
+                  "instant": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "<- write",
+                  "metric": "container_cpu",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "- avg (rate (container_fs_reads_bytes_total{namespace=\"$namespace\",pod_name=\"$pod\"}[10m])) by (pod_name)",
+                  "format": "time_series",
+                  "hide": false,
+                  "instant": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "-> read",
+                  "refId": "B"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": "",
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Disk IO",
+              "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "Bps",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 3,
+              "description": "This graph shows the % of periods where a pod is being throttled. Values range from 0-100",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {}
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 19
+              },
+              "height": "",
+              "hiddenSeries": false,
+              "id": 99,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": true,
+              "targets": [
+                {
+                  "expr": "100\n  * sum by(container_name, pod_name, namespace) (increase(container_cpu_cfs_throttled_periods_total{container_name!=\"\",namespace=~\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"}[5m]))\n  / sum by(container_name, pod_name, namespace) (increase(container_cpu_cfs_periods_total{container_name!=\"\",namespace=~\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"}[5m]))",
+                  "format": "time_series",
+                  "instant": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{container_name}}",
+                  "refId": "B"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": "",
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "CPU throttle percent",
+              "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "none",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            }
+          ],
+          "refresh": false,
+          "schemaVersion": 26,
+          "style": "dark",
+          "tags": [
+            "cost",
+            "utilization",
+            "metrics"
+          ],
+          "templating": {
+            "list": [
+              {
+                "allValue": null,
+                "current": {
+                  "selected": true,
+                  "text": "kube-system",
+                  "value": "kube-system"
+                },
+                "datasource": "${datasource}",
+                "definition": "query_result(sum(container_memory_working_set_bytes{namespace!=\"\"}) by (namespace))",
+                "hide": 0,
+                "includeAll": false,
+                "label": "ns",
+                "multi": false,
+                "name": "namespace",
+                "options": [],
+                "query": "query_result(sum(container_memory_working_set_bytes{namespace!=\"\"}) by (namespace))",
+                "refresh": 1,
+                "regex": "/namespace=\\\"(.*?)(\\\")/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "allValue": null,
+                "current": {
+                  "selected": true,
+                  "text": "heapster-gke-5759dc947d-ctckh",
+                  "value": "heapster-gke-5759dc947d-ctckh"
+                },
+                "datasource": "${datasource}",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": "pod",
+                "multi": false,
+                "name": "pod",
+                "options": [],
+                "query": "query_result(sum(container_memory_working_set_bytes{namespace=\"$namespace\"}) by (pod_name))",
+                "refresh": 1,
+                "regex": "/pod_name=\\\"(.*?)(\\\")/",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "allValue": null,
+                "current": {
+                  "isNone": true,
+                  "selected": false,
+                  "text": "None",
+                  "value": ""
+                },
+                "datasource": "${datasource}",
+                "definition": "query_result(sum(container_memory_working_set_bytes{namespace!=\"\"}) by (cluster_id))",
+                "hide": 0,
+                "includeAll": false,
+                "label": "",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "query_result(sum(container_memory_working_set_bytes{namespace!=\"\"}) by (cluster_id))",
+                "refresh": 1,
+                "regex": "/cluster_id=\\\"(.*?)(\\\")/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "current": {
+                  "selected": false,
+                  "text": "default-kubecost",
+                  "value": "default-kubecost"
+                },
+                "error": null,
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+              }
+            ]
+          },
+          "time": {
+            "from": "now-24h",
+            "to": "now"
+          },
+          "timepicker": {
+            "hidden": false,
+            "refresh_intervals": [
+              "10s",
+              "30s",
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "2h",
+              "1d"
+            ],
+            "time_options": [
+              "5m",
+              "15m",
+              "1h",
+              "6h",
+              "12h",
+              "24h",
+              "2d",
+              "7d",
+              "30d"
+            ]
+          },
+          "timezone": "browser",
+          "title": "Pod cost & utilization metrics",
+          "uid": "at-cost-analysis-pod",
+          "version": 1
+        }
+---
+# Source: cost-analyzer/templates/grafana-dashboard-prometheus-metrics-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prom-benchmark-dashboard
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+    grafana_dashboard: "1"
+  annotations:
+    {}
+data:
+    prom-benchmark.json: |-
+        {
+          "annotations": {
+            "list": [
+              {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+              }
+            ]
+          },
+          "description": "Metrics useful for benchmarking and loadtesting Prometheus itself. Designed primarily for Prometheus 2.17.x.",
+          "editable": true,
+          "gnetId": 12054,
+          "graphTooltip": 1,
+          "id": 9,
+          "iteration": 1603144824023,
+          "links": [],
+          "panels": [
+            {
+              "collapsed": false,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+              },
+              "id": 49,
+              "panels": [],
+              "title": "Basics",
+              "type": "row"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 1
+              },
+              "hiddenSeries": false,
+              "id": 40,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_build_info{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{version}} - {{revision}}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Prometheus Version",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 1
+              },
+              "hiddenSeries": false,
+              "id": 72,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "time() - process_start_time_seconds{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Age",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Uptime",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "dtdurations",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 1
+              },
+              "hiddenSeries": false,
+              "id": 107,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "time() - prometheus_config_last_reload_success_timestamp_seconds{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Age",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Last Successful Config Reload",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "dtdurations",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "collapsed": false,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 8
+              },
+              "id": 46,
+              "panels": [],
+              "title": "Ingestion",
+              "type": "row"
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833",
+                "Time series": "#70dbed"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 9
+              },
+              "hiddenSeries": false,
+              "id": 3,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_tsdb_head_series{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Time series",
+                  "metric": "prometheus_local_storage_memory_series",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Head Time series",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 9
+              },
+              "hiddenSeries": false,
+              "id": 26,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_tsdb_head_active_appenders{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Head Appenders",
+                  "metric": "prometheus_local_storage_memory_series",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Head Active Appenders",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "samples/s": "#e5a8e2"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 9
+              },
+              "hiddenSeries": false,
+              "id": 1,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "samples/s",
+                  "metric": "prometheus_local_storage_ingested_samples_total",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Samples Appended/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833",
+                "To persist": "#9AC48A"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 16
+              },
+              "hiddenSeries": false,
+              "id": 2,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                {
+                  "alias": "/Max.*/",
+                  "fill": 0
+                }
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_tsdb_head_chunks{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Chunks",
+                  "metric": "prometheus_local_storage_memory_chunks",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Head Chunks",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 16
+              },
+              "hiddenSeries": false,
+              "id": 4,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_head_chunks_created_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Created",
+                  "metric": "prometheus_local_storage_chunk_ops_total",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(prometheus_tsdb_head_chunks_removed_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Removed",
+                  "metric": "prometheus_local_storage_chunk_ops_total",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Head Chunks/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "ops",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833",
+                "Removed": "#e5ac0e"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 16
+              },
+              "hiddenSeries": false,
+              "id": 25,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_tsdb_isolation_high_watermark{job=\"prometheus\",instance=\"$Prometheus:9090\"} - prometheus_tsdb_isolation_low_watermark{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Difference",
+                  "metric": "prometheus_local_storage_chunk_ops_total",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Isolation Watermarks",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "collapsed": false,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 23
+              },
+              "id": 52,
+              "panels": [],
+              "title": "Compaction",
+              "type": "row"
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max": "#447ebc",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833",
+                "Min": "#447ebc",
+                "Now": "#7eb26d"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 24
+              },
+              "hiddenSeries": false,
+              "id": 28,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                {
+                  "alias": "Max",
+                  "fillBelowTo": "Min",
+                  "lines": false
+                }
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_tsdb_head_min_time{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Min",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "time() * 1000",
+                  "format": "time_series",
+                  "hide": false,
+                  "intervalFactor": 2,
+                  "legendFormat": "Now",
+                  "refId": "C"
+                },
+                {
+                  "expr": "prometheus_tsdb_head_max_time{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Max",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Head Time Range",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": null,
+                  "format": "dateTimeAsIso",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 24
+              },
+              "hiddenSeries": false,
+              "id": 29,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_head_gc_duration_seconds_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "GC Time/s",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Head GC Time/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 24
+              },
+              "hiddenSeries": false,
+              "id": 14,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                {
+                  "alias": "Queue length",
+                  "yaxis": 2
+                }
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_tsdb_blocks_loaded{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Blocks Loaded",
+                  "metric": "prometheus_local_storage_indexing_batch_sizes_sum",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Blocks Loaded",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Failed Compactions": "#bf1b00",
+                "Failed Reloads": "#bf1b00",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 31
+              },
+              "hiddenSeries": false,
+              "id": 30,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Reloads",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "TSDB Reloads/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "none",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Failed Compactions": "#bf1b00",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 31
+              },
+              "hiddenSeries": false,
+              "id": 31,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_wal_fsync_duration_seconds_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m]) / rate(prometheus_tsdb_wal_fsync_duration_seconds_count{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Fsync Latency",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(prometheus_tsdb_wal_truncate_duration_seconds_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[1m]) / rate(prometheus_tsdb_wal_trunacte_duration_seconds_count{job=\"prometheus\",instance=\"$Prometheus:9090\"}[1m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Truncate Latency",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "WAL Fsync&Truncate Latency",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Failed Compactions": "#bf1b00",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833",
+                "{instance=\"demo.robustperception.io:9090\",job=\"prometheus\"}": "#bf1b00"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 31
+              },
+              "hiddenSeries": false,
+              "id": 32,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_wal_corruptions_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "WAL Corruptions",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Reload Failures",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(prometheus_tsdb_head_series_not_found{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Head Series Not Found",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Compaction Failures",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(prometheus_tsdb_retention_cutoffs_failures_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Retention Cutoff Failures",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "E",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(prometheus_tsdb_checkpoint_creations_failed_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "WAL Checkpoint Creation Failures",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "F",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(prometheus_tsdb_checkpoint_deletions_failed_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "WAL Checkpoint Deletion Failures",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "G",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "TSDB Problems/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "none",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Failed Compactions": "#bf1b00",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 38
+              },
+              "hiddenSeries": false,
+              "id": 19,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_compactions_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Compactions",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Compactions/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "none",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 38
+              },
+              "hiddenSeries": false,
+              "id": 33,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_compaction_duration_seconds_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Compaction Time/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Allocated bytes": "#F9BA8F",
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833",
+                "RSS": "#890F02"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 38
+              },
+              "hiddenSeries": false,
+              "id": 8,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_time_retentions_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Time Cutoffs",
+                  "metric": "last",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(prometheus_tsdb_size_retentions_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Size Cutoffs",
+                  "metric": "last",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Retention Cutoffs/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "none",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 45
+              },
+              "hiddenSeries": false,
+              "id": 27,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Chunk Time Range",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "First Compaction, Avg Chunk Time Range",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": null,
+                  "format": "dtdurationms",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 45
+              },
+              "hiddenSeries": false,
+              "id": 35,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Bytes/Sample",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "First Compaction, Avg Bytes/Sample",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": null,
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 45
+              },
+              "hiddenSeries": false,
+              "id": 34,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_count{job=\"prometheus\",instance=\"$Prometheus:9090\"}[10m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Chunk Samples",
+                  "metric": "prometheus_local_storage_series_chunks_persisted_count",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "First Compaction, Avg Chunk Samples",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": null,
+                  "format": "none",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "collapsed": false,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 52
+              },
+              "id": 55,
+              "panels": [],
+              "title": "Resource Usage",
+              "type": "row"
+            },
+            {
+              "aliasColors": {
+                "Allocated bytes": "#7EB26D",
+                "Allocated bytes - 1m max": "#BF1B00",
+                "Allocated bytes - 1m min": "#BF1B00",
+                "Allocated bytes - 5m max": "#BF1B00",
+                "Allocated bytes - 5m min": "#BF1B00",
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833",
+                "RSS": "#447EBC"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": null,
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 53
+              },
+              "hiddenSeries": false,
+              "id": 6,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+                {
+                  "alias": "/-/",
+                  "fill": 0
+                }
+              ],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "process_resident_memory_bytes{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "RSS",
+                  "metric": "process_resident_memory_bytes",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "prometheus_local_storage_target_heap_size_bytes{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "Target heap size",
+                  "metric": "go_memstats_alloc_bytes",
+                  "refId": "D",
+                  "step": 10
+                },
+                {
+                  "expr": "go_memstats_next_gc_bytes{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "Next GC",
+                  "metric": "go_memstats_next_gc_bytes",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "expr": "go_memstats_alloc_bytes{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "Allocated",
+                  "metric": "go_memstats_alloc_bytes",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Memory",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Allocated bytes": "#F9BA8F",
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833",
+                "RSS": "#890F02"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 53
+              },
+              "hiddenSeries": false,
+              "id": 7,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(go_memstats_alloc_bytes_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Allocated Bytes/s",
+                  "metric": "go_memstats_alloc_bytes",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Allocations",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 53
+              },
+              "hiddenSeries": false,
+              "id": 9,
+              "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "irate(process_cpu_seconds_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[1m])",
+                  "intervalFactor": 2,
+                  "legendFormat": "Irate",
+                  "metric": "prometheus_local_storage_ingested_samples_total",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(process_cpu_seconds_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[5m])",
+                  "intervalFactor": 2,
+                  "legendFormat": "5m rate",
+                  "metric": "prometheus_local_storage_ingested_samples_total",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "CPU",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+                  "avg"
+                ]
+              },
+              "yaxes": [
+                {
+                  "format": "none",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 60
+              },
+              "hiddenSeries": false,
+              "id": 70,
+              "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_tsdb_symbol_table_size_bytes{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "RAM Used",
+                  "metric": "prometheus_local_storage_ingested_samples_total",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Symbol Tables Size",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+                  "avg"
+                ]
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 60
+              },
+              "hiddenSeries": false,
+              "id": 71,
+              "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_tsdb_storage_blocks_bytes_total{job=\"prometheus\",instance=\"$Prometheus:9090\"} or prometheus_tsdb_storage_blocks_bytes{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Disk Used",
+                  "metric": "prometheus_local_storage_ingested_samples_total",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Block Size",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+                  "avg"
+                ]
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Max": "#e24d42",
+                "Open": "#508642"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 60
+              },
+              "hiddenSeries": false,
+              "id": 41,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "process_max_fds{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Max",
+                  "refId": "A"
+                },
+                {
+                  "expr": "process_open_fds{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "Open",
+                  "refId": "B"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "File Descriptors",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "collapsed": false,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 67
+              },
+              "id": 91,
+              "panels": [],
+              "title": "Service Discovery",
+              "type": "row"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 68
+              },
+              "hiddenSeries": false,
+              "id": 42,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_sd_discovered_targets{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{name}}-{{config}}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Discovered Targets",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 68
+              },
+              "hiddenSeries": false,
+              "id": 96,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_sd_updates_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[5m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{name}}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Sent Updates/s",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 68
+              },
+              "hiddenSeries": false,
+              "id": 97,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_sd_received_updates_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[5m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{name}}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Received Updates/s",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "collapsed": false,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 75
+              },
+              "id": 99,
+              "panels": [],
+              "title": "Scraping",
+              "type": "row"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 76
+              },
+              "hiddenSeries": false,
+              "id": 105,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": true,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_target_interval_length_seconds_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m]) / rate(prometheus_target_interval_length_seconds_count{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{interval}}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Scrape Interval",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 76
+              },
+              "hiddenSeries": false,
+              "id": 104,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": true,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_target_scrapes_exceeded_sample_limit_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "Exceeded Sample Limit",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "Duplicate Timestamp",
+                  "refId": "C"
+                },
+                {
+                  "expr": "rate(prometheus_target_scrapes_sample_out_of_bounds_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[1m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "Out Of Bounds ",
+                  "refId": "D"
+                },
+                {
+                  "expr": "rate(prometheus_target_scrapes_sample_out_of_order_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[1m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "Out of Order",
+                  "refId": "E"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Scrape Problems/s",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "none",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 76
+              },
+              "hiddenSeries": false,
+              "id": 95,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": true,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_target_metadata_cache_bytes{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{scrape_job}}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Metadata Cache Size",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "collapsed": false,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 83
+              },
+              "id": 63,
+              "panels": [],
+              "title": "Query Engine",
+              "type": "row"
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "description": "Time spent in each mode, per second",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 84
+              },
+              "hiddenSeries": false,
+              "id": 24,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": true,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{slice}}",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Query engine timings/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 84
+              },
+              "hiddenSeries": false,
+              "id": 22,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])  ",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Rule group missed",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "expr": "rate(prometheus_rule_evaluation_failures_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[1m])",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Rule evals failed",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Rule group evaulation problems/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 84
+              },
+              "hiddenSeries": false,
+              "id": 23,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_rule_group_duration_seconds_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "Rule evaluation duration",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Evaluation time of rule groups/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "collapsed": true,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 91
+              },
+              "id": 77,
+              "panels": [
+                {
+                  "aliasColors": {
+                    "Chunks": "#1F78C1",
+                    "Chunks to persist": "#508642",
+                    "Max chunks": "#052B51",
+                    "Max to persist": "#3F6833"
+                  },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${datasource}",
+                  "editable": true,
+                  "error": false,
+                  "fieldConfig": {
+                    "defaults": {
+                      "custom": {},
+                      "links": []
+                    },
+                    "overrides": []
+                  },
+                  "fill": 1,
+                  "fillGradient": 0,
+                  "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 0,
+                    "y": 92
+                  },
+                  "hiddenSeries": false,
+                  "id": 86,
+                  "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pluginVersion": "7.1.1",
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [],
+                  "spaceLength": 10,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                    {
+                      "expr": "rate(prometheus_notifications_sent_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[1m])",
+                      "format": "time_series",
+                      "interval": "",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{alertmanager}}",
+                      "metric": "prometheus_local_storage_memory_chunkdescs",
+                      "refId": "A",
+                      "step": 10
+                    }
+                  ],
+                  "thresholds": [],
+                  "timeFrom": null,
+                  "timeRegions": [],
+                  "timeShift": null,
+                  "title": "Notification Sent/s",
+                  "tooltip": {
+                    "msResolution": false,
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                  },
+                  "yaxes": [
+                    {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": "0",
+                      "show": true
+                    },
+                    {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                    }
+                  ],
+                  "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                  }
+                },
+                {
+                  "aliasColors": {
+                    "Chunks": "#1F78C1",
+                    "Chunks to persist": "#508642",
+                    "Max chunks": "#052B51",
+                    "Max to persist": "#3F6833"
+                  },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${datasource}",
+                  "editable": true,
+                  "error": false,
+                  "fieldConfig": {
+                    "defaults": {
+                      "custom": {},
+                      "links": []
+                    },
+                    "overrides": []
+                  },
+                  "fill": 1,
+                  "fillGradient": 0,
+                  "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 8,
+                    "y": 92
+                  },
+                  "hiddenSeries": false,
+                  "id": 87,
+                  "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pluginVersion": "7.1.1",
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [],
+                  "spaceLength": 10,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                    {
+                      "expr": "rate(prometheus_notifications_errors_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m]) / rate(prometheus_notifications_sent_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                      "format": "time_series",
+                      "interval": "",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{alertmanager}}",
+                      "metric": "prometheus_local_storage_memory_chunkdescs",
+                      "refId": "A",
+                      "step": 10
+                    }
+                  ],
+                  "thresholds": [],
+                  "timeFrom": null,
+                  "timeRegions": [],
+                  "timeShift": null,
+                  "title": "Notification Error Ratio",
+                  "tooltip": {
+                    "msResolution": false,
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                  },
+                  "yaxes": [
+                    {
+                      "format": "none",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": "0",
+                      "show": true
+                    },
+                    {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                    }
+                  ],
+                  "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                  }
+                },
+                {
+                  "aliasColors": {
+                    "Chunks": "#1F78C1",
+                    "Chunks to persist": "#508642",
+                    "Max chunks": "#052B51",
+                    "Max to persist": "#3F6833"
+                  },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${datasource}",
+                  "editable": true,
+                  "error": false,
+                  "fieldConfig": {
+                    "defaults": {
+                      "custom": {},
+                      "links": []
+                    },
+                    "overrides": []
+                  },
+                  "fill": 1,
+                  "fillGradient": 0,
+                  "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 16,
+                    "y": 92
+                  },
+                  "hiddenSeries": false,
+                  "id": 81,
+                  "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pluginVersion": "7.1.1",
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [],
+                  "spaceLength": 10,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                    {
+                      "expr": "rate(prometheus_notifications_latency_seconds_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[1m]) / rate(prometheus_notifications_latency_seconds_count{job=\"prometheus\",instance=\"$Prometheus:9090\"}[1m])",
+                      "format": "time_series",
+                      "interval": "",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{alertmanager}}",
+                      "metric": "prometheus_local_storage_memory_chunkdescs",
+                      "refId": "A",
+                      "step": 10
+                    }
+                  ],
+                  "thresholds": [],
+                  "timeFrom": null,
+                  "timeRegions": [],
+                  "timeShift": null,
+                  "title": "Notification Latency",
+                  "tooltip": {
+                    "msResolution": false,
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                  },
+                  "yaxes": [
+                    {
+                      "format": "s",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": "0",
+                      "show": true
+                    },
+                    {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                    }
+                  ],
+                  "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                  }
+                },
+                {
+                  "aliasColors": {
+                    "Chunks": "#1F78C1",
+                    "Chunks to persist": "#508642",
+                    "Max chunks": "#052B51",
+                    "Max to persist": "#3F6833"
+                  },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${datasource}",
+                  "editable": true,
+                  "error": false,
+                  "fieldConfig": {
+                    "defaults": {
+                      "custom": {},
+                      "links": []
+                    },
+                    "overrides": []
+                  },
+                  "fill": 1,
+                  "fillGradient": 0,
+                  "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 0,
+                    "y": 99
+                  },
+                  "hiddenSeries": false,
+                  "id": 85,
+                  "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pluginVersion": "7.1.1",
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [],
+                  "spaceLength": 10,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                    {
+                      "expr": "prometheus_notifications_alertmanagers_discovered{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                      "format": "time_series",
+                      "interval": "",
+                      "intervalFactor": 2,
+                      "legendFormat": "Alertmanagers",
+                      "metric": "prometheus_local_storage_memory_chunkdescs",
+                      "refId": "A",
+                      "step": 10
+                    }
+                  ],
+                  "thresholds": [],
+                  "timeFrom": null,
+                  "timeRegions": [],
+                  "timeShift": null,
+                  "title": "Alertmanagers Discovered",
+                  "tooltip": {
+                    "msResolution": false,
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                  },
+                  "yaxes": [
+                    {
+                      "format": "none",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": "0",
+                      "show": true
+                    },
+                    {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                    }
+                  ],
+                  "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                  }
+                },
+                {
+                  "aliasColors": {
+                    "Chunks": "#1F78C1",
+                    "Chunks to persist": "#508642",
+                    "Max chunks": "#052B51",
+                    "Max to persist": "#3F6833"
+                  },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${datasource}",
+                  "editable": true,
+                  "error": false,
+                  "fieldConfig": {
+                    "defaults": {
+                      "custom": {},
+                      "links": []
+                    },
+                    "overrides": []
+                  },
+                  "fill": 1,
+                  "fillGradient": 0,
+                  "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 8,
+                    "y": 99
+                  },
+                  "hiddenSeries": false,
+                  "id": 89,
+                  "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pluginVersion": "7.1.1",
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [],
+                  "spaceLength": 10,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                    {
+                      "expr": "rate(prometheus_notifications_dropped_total{job=\"prometheus\",instance=\"$Prometheus:9090\"}[1m])",
+                      "format": "time_series",
+                      "interval": "",
+                      "intervalFactor": 2,
+                      "legendFormat": "Dropped",
+                      "metric": "prometheus_local_storage_memory_chunkdescs",
+                      "refId": "A",
+                      "step": 10
+                    }
+                  ],
+                  "thresholds": [],
+                  "timeFrom": null,
+                  "timeRegions": [],
+                  "timeShift": null,
+                  "title": "Notifications Dropped/s",
+                  "tooltip": {
+                    "msResolution": false,
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                  },
+                  "yaxes": [
+                    {
+                      "format": "none",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": "0",
+                      "show": true
+                    },
+                    {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                    }
+                  ],
+                  "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                  }
+                },
+                {
+                  "aliasColors": {
+                    "Chunks": "#1F78C1",
+                    "Chunks to persist": "#508642",
+                    "Max chunks": "#052B51",
+                    "Max to persist": "#3F6833"
+                  },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${datasource}",
+                  "editable": true,
+                  "error": false,
+                  "fieldConfig": {
+                    "defaults": {
+                      "custom": {},
+                      "links": []
+                    },
+                    "overrides": []
+                  },
+                  "fill": 1,
+                  "fillGradient": 0,
+                  "gridPos": {
+                    "h": 7,
+                    "w": 8,
+                    "x": 16,
+                    "y": 99
+                  },
+                  "hiddenSeries": false,
+                  "id": 88,
+                  "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pluginVersion": "7.1.1",
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [],
+                  "spaceLength": 10,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                    {
+                      "expr": "prometheus_notifications_queue_length{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                      "format": "time_series",
+                      "interval": "",
+                      "intervalFactor": 2,
+                      "legendFormat": "Pending",
+                      "metric": "prometheus_local_storage_memory_chunkdescs",
+                      "refId": "A",
+                      "step": 10
+                    },
+                    {
+                      "expr": "prometheus_notifications_queue_capacity{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                      "format": "time_series",
+                      "interval": "",
+                      "intervalFactor": 2,
+                      "legendFormat": "Max",
+                      "metric": "prometheus_local_storage_memory_chunkdescs",
+                      "refId": "B",
+                      "step": 10
+                    }
+                  ],
+                  "thresholds": [],
+                  "timeFrom": null,
+                  "timeRegions": [],
+                  "timeShift": null,
+                  "title": "Notification Queue",
+                  "tooltip": {
+                    "msResolution": false,
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                  },
+                  "yaxes": [
+                    {
+                      "format": "none",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": "0",
+                      "show": true
+                    },
+                    {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                    }
+                  ],
+                  "yaxis": {
+                    "align": false,
+                    "alignLevel": null
+                  }
+                }
+              ],
+              "title": "Notification",
+              "type": "row"
+            },
+            {
+              "collapsed": false,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 92
+              },
+              "id": 58,
+              "panels": [],
+              "title": "HTTP Server",
+              "type": "row"
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "description": "",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 93
+              },
+              "hiddenSeries": false,
+              "id": 38,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{handler}}",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "HTTP requests/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "description": "",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 93
+              },
+              "hiddenSeries": false,
+              "id": 37,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{handler}}",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "HTTP request latency",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "description": "",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 93
+              },
+              "hiddenSeries": false,
+              "id": 36,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": true,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",instance=\"$Prometheus:9090\"}[2m])",
+                  "format": "time_series",
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{handler}}",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Time spent in HTTP requests/s",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "collapsed": false,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 100
+              },
+              "id": 61,
+              "panels": [],
+              "repeat": "RuleGroup",
+              "scopedVars": {
+                "RuleGroup": {
+                  "selected": false,
+                  "text": "/etc/config/rules;CPU",
+                  "value": "/etc/config/rules;CPU"
+                }
+              },
+              "title": "Rule Group: $RuleGroup",
+              "type": "row"
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Interval": "#890f02",
+                "Last Duration": "#f9934e",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 101
+              },
+              "hiddenSeries": false,
+              "id": 43,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "repeat": null,
+              "repeatDirection": "h",
+              "scopedVars": {
+                "RuleGroup": {
+                  "selected": false,
+                  "text": "/etc/config/rules;CPU",
+                  "value": "/etc/config/rules;CPU"
+                }
+              },
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_rule_group_interval_seconds{job=\"prometheus\",instance=\"$Prometheus:9090\",rule_group=~\"$RuleGroup\"}\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Interval",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",instance=\"$Prometheus:9090\",rule_group=~\"$RuleGroup\"}\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Last Duration",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "$RuleGroup: Duration",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Interval": "#890f02",
+                "Last Duration": "#f9934e",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 101
+              },
+              "hiddenSeries": false,
+              "id": 66,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "repeatDirection": "h",
+              "scopedVars": {
+                "RuleGroup": {
+                  "selected": false,
+                  "text": "/etc/config/rules;CPU",
+                  "value": "/etc/config/rules;CPU"
+                }
+              },
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_rule_group_rules{job=\"prometheus\",instance=\"$Prometheus:9090\",rule_group=~\"$RuleGroup\"}\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Rules",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "$RuleGroup: Rules",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "none",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "collapsed": false,
+              "datasource": "${datasource}",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 108
+              },
+              "id": 108,
+              "panels": [],
+              "repeat": null,
+              "repeatIteration": 1603144824023,
+              "repeatPanelId": 61,
+              "scopedVars": {
+                "RuleGroup": {
+                  "selected": false,
+                  "text": "/etc/config/rules;Savings",
+                  "value": "/etc/config/rules;Savings"
+                }
+              },
+              "title": "Rule Group: $RuleGroup",
+              "type": "row"
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Interval": "#890f02",
+                "Last Duration": "#f9934e",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 109
+              },
+              "hiddenSeries": false,
+              "id": 109,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "repeat": null,
+              "repeatDirection": "h",
+              "repeatIteration": 1603144824023,
+              "repeatPanelId": 43,
+              "repeatedByRow": true,
+              "scopedVars": {
+                "RuleGroup": {
+                  "selected": false,
+                  "text": "/etc/config/rules;Savings",
+                  "value": "/etc/config/rules;Savings"
+                }
+              },
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_rule_group_interval_seconds{job=\"prometheus\",instance=\"$Prometheus:9090\",rule_group=~\"$RuleGroup\"}\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Interval",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "expr": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",instance=\"$Prometheus:9090\",rule_group=~\"$RuleGroup\"}\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Last Duration",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "$RuleGroup: Duration",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "s",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {
+                "Chunks": "#1F78C1",
+                "Chunks to persist": "#508642",
+                "Interval": "#890f02",
+                "Last Duration": "#f9934e",
+                "Max chunks": "#052B51",
+                "Max to persist": "#3F6833"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "${datasource}",
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {},
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 109
+              },
+              "hiddenSeries": false,
+              "id": 110,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "percentage": false,
+              "pluginVersion": "7.1.1",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "repeatDirection": "h",
+              "repeatIteration": 1603144824023,
+              "repeatPanelId": 66,
+              "repeatedByRow": true,
+              "scopedVars": {
+                "RuleGroup": {
+                  "selected": false,
+                  "text": "/etc/config/rules;Savings",
+                  "value": "/etc/config/rules;Savings"
+                }
+              },
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "prometheus_rule_group_rules{job=\"prometheus\",instance=\"$Prometheus:9090\",rule_group=~\"$RuleGroup\"}\n",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Rules",
+                  "metric": "prometheus_local_storage_memory_chunkdescs",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "$RuleGroup: Rules",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "none",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            }
+          ],
+          "refresh": false,
+          "schemaVersion": 26,
+          "style": "dark",
+          "tags": [],
+          "templating": {
+            "list": [
+              {
+                "allValue": null,
+                "current": {
+                  "selected": false,
+                  "text": "localhost",
+                  "value": "localhost"
+                },
+                "datasource": "${datasource}",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "Prometheus",
+                "options": [],
+                "query": "query_result(up{job=\"prometheus\"} == 1)",
+                "refresh": 2,
+                "regex": ".*instance=\"([^\"]+):9090\".*",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": null,
+                "tags": [],
+                "tagsQuery": null,
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "allValue": null,
+                "current": {
+                  "selected": false,
+                  "text": "All",
+                  "value": "$__all"
+                },
+                "datasource": "${datasource}",
+                "definition": "",
+                "hide": 2,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "RuleGroup",
+                "options": [],
+                "query": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",instance=\"$Prometheus:9090\"}",
+                "refresh": 2,
+                "regex": ".*rule_group=\"(.*?)\".*",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+              },
+              {
+                "current": {
+                  "selected": true,
+                  "text": "default-kubecost",
+                  "value": "default-kubecost"
+                },
+                "error": null,
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+              }
+            ]
+          },
+          "time": {
+            "from": "now-24h",
+            "to": "now"
+          },
+          "timepicker": {
+            "refresh_intervals": [
+              "10s",
+              "30s",
+              "1m",
+              "5m",
+              "15m",
+              "30m",
+              "1h",
+              "2h",
+              "1d"
+            ],
+            "time_options": [
+              "5m",
+              "15m",
+              "1h",
+              "6h",
+              "12h",
+              "24h",
+              "2d",
+              "7d",
+              "30d"
+            ]
+          },
+          "timezone": "utc",
+          "title": "Prometheus Benchmark - 2.17.x",
+          "uid": "L0HBvojWz",
+          "version": 4
+        }
+---
+# Source: cost-analyzer/charts/prometheus/templates/server-pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+    release: kubecost
+    chart: prometheus-11.0.2
+    heritage: Helm
+  name: kubecost-prometheus-server
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "32Gi"
+---
+# Source: cost-analyzer/templates/cost-analyzer-pvc-template.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: kubecost-cost-analyzer
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 32Gi
+---
+# Source: cost-analyzer/charts/grafana/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    release: kubecost
+    heritage: Helm
+  name: kubecost-grafana-clusterrole
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list"]
+---
+# Source: cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    helm.sh/chart: kube-state-metrics-2.7.2
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kubecost
+  name: kubecost-kube-state-metrics
+rules:
+
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["list", "watch"]
+
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - limitranges
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumes
+  verbs: ["list", "watch"]
+
+- apiGroups: ["policy"]
+  resources:
+    - poddisruptionbudgets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - replicasets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - replicationcontrollers
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
+  verbs: ["list", "watch"]
+---
+# Source: cost-analyzer/charts/prometheus/templates/server-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+    release: kubecost
+    chart: prometheus-11.0.2
+    heritage: Helm
+  name: kubecost-prometheus-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - ingresses
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get
+---
+# Source: cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubecost
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - deployments
+      - nodes
+      - pods
+      - events
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+      - daemonsets
+      - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: cost-analyzer/charts/grafana/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubecost-grafana-clusterrolebinding
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    release: kubecost
+    heritage: Helm
+subjects:
+  - kind: ServiceAccount
+    name: kubecost-grafana
+    namespace: kubecost
+roleRef:
+  kind: ClusterRole
+  name: kubecost-grafana-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    helm.sh/chart: kube-state-metrics-2.7.2
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: kubecost
+  name: kubecost-kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubecost-kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kubecost-kube-state-metrics
+  namespace: kubecost
+---
+# Source: cost-analyzer/charts/prometheus/templates/server-clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+    release: kubecost
+    chart: prometheus-11.0.2
+    heritage: Helm
+  name: kubecost-prometheus-server
+subjects:
+  - kind: ServiceAccount
+    name: kubecost-prometheus-server
+    namespace: kubecost
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubecost-prometheus-server
+---
+# Source: cost-analyzer/templates/cost-analyzer-cluster-role-binding-template.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubecost
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubecost
+subjects:
+  - kind: ServiceAccount
+    name: kubecost-cost-analyzer
+    namespace: kubecost
+---
+# Source: cost-analyzer/charts/grafana/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubecost-grafana
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    heritage: Helm
+    release: kubecost
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [kubecost-grafana]
+---
+# Source: cost-analyzer/templates/cost-analyzer-cluster-role-template.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kubecost
+  name: kubecost
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+rules:
+- apiGroups:
+    - ''
+  resources:
+    - "pods/log"
+  verbs:
+    - get
+    - list
+    - watch
+---
+# Source: cost-analyzer/templates/cost-analyzer-psp-role.template.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubecost-cost-analyzer-psp
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+  annotations:
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - kubecost-cost-analyzer-psp
+---
+# Source: cost-analyzer/charts/grafana/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubecost-grafana
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    heritage: Helm
+    release: kubecost
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubecost-grafana
+subjects:
+- kind: ServiceAccount
+  name: kubecost-grafana
+---
+# Source: cost-analyzer/templates/cost-analyzer-cluster-role-binding-template.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubecost
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubecost
+subjects:
+  - kind: ServiceAccount
+    name: kubecost-cost-analyzer
+    namespace: kubecost
+---
+# Source: cost-analyzer/templates/cost-analyzer-psp-rolebinding.template.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kubecost-cost-analyzer-psp
+    labels:
+
+      app.kubernetes.io/name: cost-analyzer
+      helm.sh/chart: cost-analyzer-1.97.0
+      app.kubernetes.io/instance: kubecost
+      app.kubernetes.io/managed-by: Helm
+      app: cost-analyzer
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: kubecost-cost-analyzer-psp
+subjects:
+- kind: ServiceAccount
+  name: kubecost-cost-analyzer
+  namespace: kubecost
+---
+# Source: cost-analyzer/charts/grafana/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubecost-grafana
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    release: kubecost
+    heritage: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-service
+      port: 80
+      protocol: TCP
+      targetPort: 3000
+
+  selector:
+    app: grafana
+    release: kubecost
+---
+# Source: cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubecost-kube-state-metrics
+  namespace: kubecost
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    helm.sh/chart: "kube-state-metrics-2.7.2"
+    app.kubernetes.io/instance: "kubecost"
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  type: "ClusterIP"
+  ports:
+  - name: "http"
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: kubecost
+---
+# Source: cost-analyzer/charts/prometheus/templates/node-exporter-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+  labels:
+    component: "node-exporter"
+    app: prometheus
+    release: kubecost
+    chart: prometheus-11.0.2
+    heritage: Helm
+  name: kubecost-prometheus-node-exporter
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9100
+      protocol: TCP
+      targetPort: 9100
+  selector:
+    component: "node-exporter"
+    app: prometheus
+    release: kubecost
+  type: "ClusterIP"
+---
+# Source: cost-analyzer/charts/prometheus/templates/server-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+    release: kubecost
+    chart: prometheus-11.0.2
+    heritage: Helm
+  name: kubecost-prometheus-server
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    component: "server"
+    app: prometheus
+    release: kubecost
+  sessionAffinity: None
+  type: "ClusterIP"
+---
+# Source: cost-analyzer/templates/cost-analyzer-service-template.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: kubecost-cost-analyzer
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+spec:
+  selector:
+
+    app.kubernetes.io/name: cost-analyzer
+    app.kubernetes.io/instance: kubecost
+    app: cost-analyzer
+  type: "ClusterIP"
+  ports:
+    - name: tcp-model
+      port: 9003
+      targetPort: 9003
+    - name: tcp-frontend
+      port: 9090
+      targetPort: 9090
+---
+# Source: cost-analyzer/charts/prometheus/templates/node-exporter-daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    component: "node-exporter"
+    app: prometheus
+    release: kubecost
+    chart: prometheus-11.0.2
+    heritage: Helm
+  name: kubecost-prometheus-node-exporter
+spec:
+  selector:
+    matchLabels:
+      component: "node-exporter"
+      app: prometheus
+      release: kubecost
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        component: "node-exporter"
+        app: prometheus
+        release: kubecost
+        chart: prometheus-11.0.2
+        heritage: Helm
+    spec:
+      serviceAccountName: kubecost-prometheus-node-exporter
+      containers:
+        - name: prometheus-node-exporter
+          image: "prom/node-exporter:v1.3.0"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --web.listen-address=:9100
+          ports:
+            - name: metrics
+              containerPort: 9100
+              hostPort: 9100
+          resources:
+            {}
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly:  true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+      hostNetwork: true
+      hostPID: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+---
+# Source: cost-analyzer/charts/grafana/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubecost-grafana
+  labels:
+    app: grafana
+    chart: grafana-1.17.2
+    release: kubecost
+    heritage: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+      release: kubecost
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: grafana
+        release: kubecost
+    spec:
+      serviceAccountName: kubecost-grafana
+      securityContext:
+        fsGroup: 472
+        runAsUser: 472
+      containers:
+        - name: grafana-sc-dashboard
+          image: "kiwigrid/k8s-sidecar:1.19.2"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: LABEL
+              value: "grafana_dashboard"
+            - name: FOLDER
+              value: "/tmp/dashboards"
+            - name: ERROR_THROTTLE_SLEEP
+              value: "0"
+          resources:
+            null
+          volumeMounts:
+            - name: sc-dashboard-volume
+              mountPath: "/tmp/dashboards"
+        - name: grafana
+          image: "grafana/grafana:9.0.2"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: config
+              mountPath: "/etc/grafana/grafana.ini"
+              subPath: grafana.ini
+            - name: ldap
+              mountPath: "/etc/grafana/ldap.toml"
+              subPath: ldap.toml
+            - name: config
+              mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
+              subPath: datasources.yaml
+            - name: sc-dashboard-volume
+              mountPath: "/tmp/dashboards"
+            - name: sc-dashboard-provider
+              mountPath: "/etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml"
+              subPath: provider.yaml
+            - name: storage
+              mountPath: "/var/lib/grafana"
+              subPath:
+          ports:
+            - name: service
+              containerPort: 80
+              protocol: TCP
+            - name: grafana
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: kubecost-grafana
+                  key: admin-user
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kubecost-grafana
+                  key: admin-password
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 60
+            timeoutSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+          resources:
+            {}
+      volumes:
+        - name: config
+          configMap:
+            name: kubecost-grafana
+        - name: ldap
+          secret:
+            secretName: kubecost-grafana
+            items:
+              - key: ldap-toml
+                path: ldap.toml
+        - name: storage
+          emptyDir: {}
+        - name: sc-dashboard-volume
+          emptyDir: {}
+        - name: sc-dashboard-provider
+          configMap:
+            name: kubecost-grafana-config-dashboards
+---
+# Source: cost-analyzer/charts/prometheus/charts/kube-state-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubecost-kube-state-metrics
+  namespace: kubecost
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    helm.sh/chart: "kube-state-metrics-2.7.2"
+    app.kubernetes.io/instance: "kubecost"
+    app.kubernetes.io/managed-by: "Helm"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/instance: "kubecost"
+    spec:
+      hostNetwork: false
+      serviceAccountName: kubecost-kube-state-metrics
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      containers:
+      - name: kube-state-metrics
+        args:
+
+        - --collectors=certificatesigningrequests
+
+
+        - --collectors=configmaps
+
+
+        - --collectors=cronjobs
+
+
+        - --collectors=daemonsets
+
+
+        - --collectors=deployments
+
+
+        - --collectors=endpoints
+
+
+        - --collectors=horizontalpodautoscalers
+
+
+        - --collectors=ingresses
+
+
+        - --collectors=jobs
+
+
+        - --collectors=limitranges
+
+
+
+        - --collectors=namespaces
+
+
+
+        - --collectors=nodes
+
+
+        - --collectors=persistentvolumeclaims
+
+
+        - --collectors=persistentvolumes
+
+
+        - --collectors=poddisruptionbudgets
+
+
+        - --collectors=pods
+
+
+        - --collectors=replicasets
+
+
+        - --collectors=replicationcontrollers
+
+
+        - --collectors=resourcequotas
+
+
+
+        - --collectors=services
+
+
+        - --collectors=statefulsets
+
+
+        - --collectors=storageclasses
+
+
+
+
+
+
+        imagePullPolicy: IfNotPresent
+        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8"
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+---
+# Source: cost-analyzer/charts/prometheus/templates/server-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: "server"
+    app: prometheus
+    release: kubecost
+    chart: prometheus-11.0.2
+    heritage: Helm
+  name: kubecost-prometheus-server
+spec:
+  selector:
+    matchLabels:
+      component: "server"
+      app: prometheus
+      release: kubecost
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        component: "server"
+        app: prometheus
+        release: kubecost
+        chart: prometheus-11.0.2
+        heritage: Helm
+    spec:
+      serviceAccountName: kubecost-prometheus-server
+      containers:
+        - name: prometheus-server-configmap-reload
+          image: "jimmidyson/configmap-reload:v0.7.1"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --volume-dir=/etc/config
+            - --webhook-url=http://127.0.0.1:9090/-/reload
+          resources:
+            {}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+              readOnly: true
+
+        - name: prometheus-server
+          image: "quay.io/prometheus/prometheus:v2.35.0"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --storage.tsdb.retention.time=15d
+            - --config.file=/etc/config/prometheus.yml
+            - --storage.tsdb.path=/data
+            - --web.console.libraries=/etc/prometheus/console_libraries
+            - --web.console.templates=/etc/prometheus/consoles
+            - --web.enable-lifecycle
+            - --query.max-concurrency=1
+            - --query.max-samples=1e+08
+          ports:
+            - containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 3
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 3
+            successThreshold: 1
+          resources:
+            {}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: storage-volume
+              mountPath: /data
+              subPath: ""
+      securityContext:
+        fsGroup: 1001
+        runAsGroup: 1001
+        runAsNonRoot: true
+        runAsUser: 1001
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - name: config-volume
+          configMap:
+            name: kubecost-prometheus-server
+        - name: storage-volume
+          persistentVolumeClaim:
+            claimName: kubecost-prometheus-server
+---
+# Source: cost-analyzer/templates/cost-analyzer-deployment-template.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubecost-cost-analyzer
+  labels:
+
+    app.kubernetes.io/name: cost-analyzer
+    helm.sh/chart: cost-analyzer-1.97.0
+    app.kubernetes.io/instance: kubecost
+    app.kubernetes.io/managed-by: Helm
+    app: cost-analyzer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+
+        app.kubernetes.io/name: cost-analyzer
+        app.kubernetes.io/instance: kubecost
+        app: cost-analyzer
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+
+        app.kubernetes.io/name: cost-analyzer
+        app.kubernetes.io/instance: kubecost
+        app: cost-analyzer
+    spec:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      restartPolicy: Always
+      serviceAccountName: kubecost-cost-analyzer
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: nginx-conf
+            items:
+              - key: nginx.conf
+                path: default.conf
+        - name: persistent-configs
+          persistentVolumeClaim:
+            claimName: kubecost-cost-analyzer
+      initContainers:
+      containers:
+        - image: gcr.io/kubecost1/cost-model:prod-1.97.0
+
+          name: cost-model
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 200m
+              memory: 55Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 200
+          volumeMounts:
+            - name: persistent-configs
+              mountPath: /var/configs
+          env:
+            - name: GRAFANA_ENABLED
+              value: "true"
+            - name: HELM_VALUES
+              value: eyJhZmZpbml0eSI6e30sImF3c3N0b3JlIjp7ImNyZWF0ZVNlcnZpY2VBY2NvdW50IjpmYWxzZSwidXNlQXdzU3RvcmUiOmZhbHNlfSwiZXh0cmFWb2x1bWVNb3VudHMiOltdLCJleHRyYVZvbHVtZXMiOltdLCJnbG9iYWwiOnsiYWRkaXRpb25hbExhYmVscyI6e30sImdyYWZhbmEiOnsiZG9tYWluTmFtZSI6ImNvc3QtYW5hbHl6ZXItZ3JhZmFuYS5kZWZhdWx0LnN2YyIsImVuYWJsZWQiOnRydWUsInByb3h5Ijp0cnVlLCJzY2hlbWUiOiJodHRwIn0sIm5vdGlmaWNhdGlvbnMiOnt9LCJwb2RBbm5vdGF0aW9ucyI6e30sInByb21ldGhldXMiOnsiZW5hYmxlZCI6dHJ1ZSwiZnFkbiI6Imh0dHA6Ly9jb3N0LWFuYWx5emVyLXByb21ldGhldXMtc2VydmVyLmRlZmF1bHQuc3ZjIn19LCJncmFmYW5hIjp7ImFkbWluUGFzc3dvcmQiOiJzdHJvbmdwYXNzd29yZCIsImFkbWluVXNlciI6ImFkbWluIiwiYWZmaW5pdHkiOnt9LCJkYXNoYm9hcmRQcm92aWRlcnMiOnt9LCJkYXNoYm9hcmRzIjp7fSwiZGFzaGJvYXJkc0NvbmZpZ01hcHMiOnt9LCJkYXRhc291cmNlcyI6eyJkYXRhc291cmNlcy55YW1sIjp7ImFwaVZlcnNpb24iOjEsImRhdGFzb3VyY2VzIjpbeyJhY2Nlc3MiOiJwcm94eSIsImlzRGVmYXVsdCI6ZmFsc2UsIm5hbWUiOiJwcm9tZXRoZXVzLWt1YmVjb3N0IiwidHlwZSI6InByb21ldGhldXMiLCJ1cmwiOiJodHRwOi8va3ViZWNvc3QtcHJvbWV0aGV1cy1zZXJ2ZXIua3ViZWNvc3Quc3ZjLmNsdXN0ZXIubG9jYWwifV19fSwiZGVwbG95bWVudFN0cmF0ZWd5IjoiUm9sbGluZ1VwZGF0ZSIsImRvd25sb2FkRGFzaGJvYXJkc0ltYWdlIjp7InB1bGxQb2xpY3kiOiJJZk5vdFByZXNlbnQiLCJyZXBvc2l0b3J5IjoiY3VybGltYWdlcy9jdXJsIiwidGFnIjoibGF0ZXN0In0sImVudiI6e30sImVudkZyb21TZWNyZXQiOiIiLCJleHRyYVNlY3JldE1vdW50cyI6W10sImdsb2JhbCI6eyJhZGRpdGlvbmFsTGFiZWxzIjp7fSwiZ3JhZmFuYSI6eyJkb21haW5OYW1lIjoiY29zdC1hbmFseXplci1ncmFmYW5hLmRlZmF1bHQuc3ZjIiwiZW5hYmxlZCI6dHJ1ZSwicHJveHkiOnRydWUsInNjaGVtZSI6Imh0dHAifSwibm90aWZpY2F0aW9ucyI6e30sInBvZEFubm90YXRpb25zIjp7fSwicHJvbWV0aGV1cyI6eyJlbmFibGVkIjp0cnVlLCJmcWRuIjoiaHR0cDovL2Nvc3QtYW5hbHl6ZXItcHJvbWV0aGV1cy1zZXJ2ZXIuZGVmYXVsdC5zdmMifX0sImdyYWZhbmEuaW5pIjp7ImFuYWx5dGljcyI6eyJjaGVja19mb3JfdXBkYXRlcyI6dHJ1ZX0sImF1dGguYW5vbnltb3VzIjp7ImVuYWJsZWQiOnRydWUsIm9yZ19uYW1lIjoiTWFpbiBPcmcuIiwib3JnX3JvbGUiOiJFZGl0b3IifSwiZ3JhZmFuYV9uZXQiOnsidXJsIjoiaHR0cHM6Ly9ncmFmYW5hLm5ldCJ9LCJsb2ciOnsibW9kZSI6ImNvbnNvbGUifSwicGF0aHMiOnsiZGF0YSI6Ii92YXIvbGliL2dyYWZhbmEvZGF0YSIsImxvZ3MiOiIvdmFyL2xvZy9ncmFmYW5hIiwicGx1Z2lucyI6Ii92YXIvbGliL2dyYWZhbmEvcGx1Z2lucyIsInByb3Zpc2lvbmluZyI6Ii9ldGMvZ3JhZmFuYS9wcm92aXNpb25pbmcifSwic2VydmVyIjp7InJvb3RfdXJsIjoiJShwcm90b2NvbClzOi8vJShkb21haW4pczolKGh0dHBfcG9ydClzL2dyYWZhbmEifX0sImltYWdlIjp7InB1bGxQb2xpY3kiOiJJZk5vdFByZXNlbnQiLCJyZXBvc2l0b3J5IjoiZ3JhZmFuYS9ncmFmYW5hIiwidGFnIjoiOS4wLjIifSwibGRhcCI6eyJjb25maWciOiIiLCJleGlzdGluZ1NlY3JldCI6IiJ9LCJsaXZlbmVzc1Byb2JlIjp7ImZhaWx1cmVUaHJlc2hvbGQiOjEwLCJodHRwR2V0Ijp7InBhdGgiOiIvYXBpL2hlYWx0aCIsInBvcnQiOjMwMDB9LCJpbml0aWFsRGVsYXlTZWNvbmRzIjo2MCwidGltZW91dFNlY29uZHMiOjMwfSwibm9kZVNlbGVjdG9yIjp7fSwicGx1Z2lucyI6W10sInJiYWMiOnsiY3JlYXRlIjp0cnVlLCJwc3BFbmFibGVkIjp0cnVlLCJwc3BVc2VBcHBBcm1vciI6dHJ1ZX0sInJlYWRpbmVzc1Byb2JlIjp7Imh0dHBHZXQiOnsicGF0aCI6Ii9hcGkvaGVhbHRoIiwicG9ydCI6MzAwMH19LCJyZXBsaWNhcyI6MSwicmVzb3VyY2VzIjp7fSwic2VjdXJpdHlDb250ZXh0Ijp7ImZzR3JvdXAiOjQ3MiwicnVuQXNVc2VyIjo0NzJ9LCJzZXJ2aWNlIjp7ImFubm90YXRpb25zIjp7fSwibGFiZWxzIjp7fSwicG9ydCI6ODAsInR5cGUiOiJDbHVzdGVySVAifSwic2VydmljZUFjY291bnQiOnsiY3JlYXRlIjp0cnVlfSwic2lkZWNhciI6eyJkYXNoYm9hcmRzIjp7ImFubm90YXRpb25zIjp7fSwiZW5hYmxlZCI6dHJ1ZSwiZXJyb3JfdGhyb3R0bGVfc2xlZXAiOjAsImZvbGRlciI6Ii90bXAvZGFzaGJvYXJkcyIsImxhYmVsIjoiZ3JhZmFuYV9kYXNoYm9hcmQifSwiaW1hZ2UiOiJraXdpZ3JpZC9rOHMtc2lkZWNhcjoxLjE5LjIiLCJpbWFnZVB1bGxQb2xpY3kiOiJJZk5vdFByZXNlbnQiLCJyZXNvdXJjZXMiOm51bGx9LCJzbXRwIjp7ImV4aXN0aW5nU2VjcmV0IjoiIn0sInRvbGVyYXRpb25zIjpbXX0sImluaXRDaG93bkRhdGEiOnsicmVzb3VyY2VzIjp7fX0sImluaXRDaG93bkRhdGFJbWFnZSI6ImJ1c3lib3giLCJrdWJlY29zdERlcGxveW1lbnQiOnsicmVwbGljYXMiOjF9LCJrdWJlY29zdEZyb250ZW5kIjp7ImltYWdlIjoiZ2NyLmlvL2t1YmVjb3N0MS9mcm9udGVuZCIsImltYWdlUHVsbFBvbGljeSI6IkFsd2F5cyIsImlwdjYiOnsiZW5hYmxlZCI6dHJ1ZX0sInJlc291cmNlcyI6eyJyZXF1ZXN0cyI6eyJjcHUiOiIxMG0iLCJtZW1vcnkiOiI1NU1pIn19fSwia3ViZWNvc3RNZXRyaWNzIjp7fSwia3ViZWNvc3RNb2RlbCI6eyJldGwiOnRydWUsImV0bERhaWx5U3RvcmVEdXJhdGlvbkRheXMiOjkxLCJldGxGaWxlU3RvcmVFbmFibGVkIjp0cnVlLCJldGxIb3VybHlTdG9yZUR1cmF0aW9uSG91cnMiOjQ5LCJldGxSZWFkT25seU1vZGUiOmZhbHNlLCJleHRyYUFyZ3MiOltdLCJpbWFnZSI6Imdjci5pby9rdWJlY29zdDEvY29zdC1tb2RlbCIsImltYWdlUHVsbFBvbGljeSI6IkFsd2F5cyIsIm1heFF1ZXJ5Q29uY3VycmVuY3kiOjUsIm91dE9mQ2x1c3RlclByb21NZXRyaWNzRW5hYmxlZCI6ZmFsc2UsInJlc291cmNlcyI6eyJyZXF1ZXN0cyI6eyJjcHUiOiIyMDBtIiwibWVtb3J5IjoiNTVNaSJ9fSwid2FybUNhY2hlIjpmYWxzZSwid2FybVNhdmluZ3NDYWNoZSI6dHJ1ZX0sImt1YmVjb3N0VG9rZW4iOm51bGwsIm5vZGVTZWxlY3RvciI6e30sInBlcnNpc3RlbnRWb2x1bWUiOnsiZGJTaXplIjoiMzIuMEdpIiwiZW5hYmxlZCI6dHJ1ZSwic2l6ZSI6IjMyR2kifSwicG9kU2VjdXJpdHlQb2xpY3kiOnsiZW5hYmxlZCI6dHJ1ZX0sInByb21ldGhldXMiOnsiYWxlcnRSZWxhYmVsQ29uZmlncyI6bnVsbCwiYWxlcnRtYW5hZ2VyRmlsZXMiOnsiYWxlcnRtYW5hZ2VyLnltbCI6eyJnbG9iYWwiOnt9LCJyZWNlaXZlcnMiOlt7Im5hbWUiOiJkZWZhdWx0LXJlY2VpdmVyIn1dLCJyb3V0ZSI6eyJncm91cF9pbnRlcnZhbCI6IjVtIiwiZ3JvdXBfd2FpdCI6IjEwcyIsInJlY2VpdmVyIjoiZGVmYXVsdC1yZWNlaXZlciIsInJlcGVhdF9pbnRlcnZhbCI6IjNoIn19fSwiY29uZmlnbWFwUmVsb2FkIjp7ImFsZXJ0bWFuYWdlciI6eyJlbmFibGVkIjp0cnVlLCJleHRyYUFyZ3MiOnt9LCJleHRyYUNvbmZpZ21hcE1vdW50cyI6W10sImV4dHJhVm9sdW1lRGlycyI6W10sImltYWdlIjp7InB1bGxQb2xpY3kiOiJJZk5vdFByZXNlbnQiLCJyZXBvc2l0b3J5IjoiamltbWlkeXNvbi9jb25maWdtYXAtcmVsb2FkIiwidGFnIjoidjAuNy4xIn0sIm5hbWUiOiJjb25maWdtYXAtcmVsb2FkIiwicmVzb3VyY2VzIjp7fX0sInByb21ldGhldXMiOnsiZW5hYmxlZCI6dHJ1ZSwiZXh0cmFBcmdzIjp7fSwiZXh0cmFDb25maWdtYXBNb3VudHMiOltdLCJleHRyYVZvbHVtZURpcnMiOltdLCJpbWFnZSI6eyJwdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwicmVwb3NpdG9yeSI6ImppbW1pZHlzb24vY29uZmlnbWFwLXJlbG9hZCIsInRhZyI6InYwLjcuMSJ9LCJuYW1lIjoiY29uZmlnbWFwLXJlbG9hZCIsInJlc291cmNlcyI6e319fSwiZXh0cmFTY3JhcGVDb25maWdzIjoiLSBqb2JfbmFtZToga3ViZWNvc3RcbiAgaG9ub3JfbGFiZWxzOiB0cnVlXG4gIHNjcmFwZV9pbnRlcnZhbDogMW1cbiAgc2NyYXBlX3RpbWVvdXQ6IDYwc1xuICBtZXRyaWNzX3BhdGg6IC9tZXRyaWNzXG4gIHNjaGVtZTogaHR0cFxuICBkbnNfc2RfY29uZmlnczpcbiAgLSBuYW1lczpcbiAgICAtIHt7IHRlbXBsYXRlIFwiY29zdC1hbmFseXplci5zZXJ2aWNlTmFtZVwiIC4gfX1cbiAgICB0eXBlOiAnQSdcbiAgICBwb3J0OiA5MDAzXG4tIGpvYl9uYW1lOiBrdWJlY29zdC1uZXR3b3JraW5nXG4gIGt1YmVybmV0ZXNfc2RfY29uZmlnczpcbiAgICAtIHJvbGU6IHBvZFxuICByZWxhYmVsX2NvbmZpZ3M6XG4gICMgU2NyYXBlIG9ubHkgdGhlIHRoZSB0YXJnZXRzIG1hdGNoaW5nIHRoZSBmb2xsb3dpbmcgbWV0YWRhdGFcbiAgICAtIHNvdXJjZV9sYWJlbHM6IFtfX21ldGFfa3ViZXJuZXRlc19wb2RfbGFiZWxfYXBwXVxuICAgICAgYWN0aW9uOiBrZWVwXG4gICAgICByZWdleDogIHt7IHRlbXBsYXRlIFwiY29zdC1hbmFseXplci5uZXR3b3JrQ29zdHNOYW1lXCIgLiB9fVxuIiwiZ2xvYmFsIjp7ImFkZGl0aW9uYWxMYWJlbHMiOnt9LCJncmFmYW5hIjp7ImRvbWFpbk5hbWUiOiJjb3N0LWFuYWx5emVyLWdyYWZhbmEuZGVmYXVsdC5zdmMiLCJlbmFibGVkIjp0cnVlLCJwcm94eSI6dHJ1ZSwic2NoZW1lIjoiaHR0cCJ9LCJub3RpZmljYXRpb25zIjp7fSwicG9kQW5ub3RhdGlvbnMiOnt9LCJwcm9tZXRoZXVzIjp7ImVuYWJsZWQiOnRydWUsImZxZG4iOiJodHRwOi8vY29zdC1hbmFseXplci1wcm9tZXRoZXVzLXNlcnZlci5kZWZhdWx0LnN2YyJ9fSwiaW1hZ2VQdWxsU2VjcmV0cyI6bnVsbCwia3ViZS1zdGF0ZS1tZXRyaWNzIjp7ImFmZmluaXR5Ijp7fSwiY29sbGVjdG9ycyI6eyJjZXJ0aWZpY2F0ZXNpZ25pbmdyZXF1ZXN0cyI6dHJ1ZSwiY29uZmlnbWFwcyI6dHJ1ZSwiY3JvbmpvYnMiOnRydWUsImRhZW1vbnNldHMiOnRydWUsImRlcGxveW1lbnRzIjp0cnVlLCJlbmRwb2ludHMiOnRydWUsImhvcml6b250YWxwb2RhdXRvc2NhbGVycyI6dHJ1ZSwiaW5ncmVzc2VzIjp0cnVlLCJqb2JzIjp0cnVlLCJsaW1pdHJhbmdlcyI6dHJ1ZSwibXV0YXRpbmd3ZWJob29rY29uZmlndXJhdGlvbnMiOmZhbHNlLCJuYW1lc3BhY2VzIjp0cnVlLCJuZXR3b3JrcG9saWNpZXMiOmZhbHNlLCJub2RlcyI6dHJ1ZSwicGVyc2lzdGVudHZvbHVtZWNsYWltcyI6dHJ1ZSwicGVyc2lzdGVudHZvbHVtZXMiOnRydWUsInBvZGRpc3J1cHRpb25idWRnZXRzIjp0cnVlLCJwb2RzIjp0cnVlLCJyZXBsaWNhc2V0cyI6dHJ1ZSwicmVwbGljYXRpb25jb250cm9sbGVycyI6dHJ1ZSwicmVzb3VyY2VxdW90YXMiOnRydWUsInNlY3JldHMiOmZhbHNlLCJzZXJ2aWNlcyI6dHJ1ZSwic3RhdGVmdWxzZXRzIjp0cnVlLCJzdG9yYWdlY2xhc3NlcyI6dHJ1ZSwidmFsaWRhdGluZ3dlYmhvb2tjb25maWd1cmF0aW9ucyI6ZmFsc2UsInZlcnRpY2FscG9kYXV0b3NjYWxlcnMiOmZhbHNlLCJ2b2x1bWVhdHRhY2htZW50cyI6ZmFsc2V9LCJjdXN0b21MYWJlbHMiOnt9LCJkaXNhYmxlZCI6ZmFsc2UsImVuYWJsZWQiOnRydWUsImdsb2JhbCI6eyJhZGRpdGlvbmFsTGFiZWxzIjp7fSwiZ3JhZmFuYSI6eyJkb21haW5OYW1lIjoiY29zdC1hbmFseXplci1ncmFmYW5hLmRlZmF1bHQuc3ZjIiwiZW5hYmxlZCI6dHJ1ZSwicHJveHkiOnRydWUsInNjaGVtZSI6Imh0dHAifSwibm90aWZpY2F0aW9ucyI6e30sInBvZEFubm90YXRpb25zIjp7fSwicHJvbWV0aGV1cyI6eyJlbmFibGVkIjp0cnVlLCJmcWRuIjoiaHR0cDovL2Nvc3QtYW5hbHl6ZXItcHJvbWV0aGV1cy1zZXJ2ZXIuZGVmYXVsdC5zdmMifX0sImhvc3ROZXR3b3JrIjpmYWxzZSwiaW1hZ2UiOnsicHVsbFBvbGljeSI6IklmTm90UHJlc2VudCIsInJlcG9zaXRvcnkiOiJrOHMuZ2NyLmlvL2t1YmUtc3RhdGUtbWV0cmljcy9rdWJlLXN0YXRlLW1ldHJpY3MiLCJ0YWciOiJ2MS45LjgifSwibmFtZXNwYWNlT3ZlcnJpZGUiOiIiLCJub2RlU2VsZWN0b3IiOnt9LCJwb2RBbm5vdGF0aW9ucyI6e30sInByb21ldGhldXMiOnt9LCJwcm9tZXRoZXVzU2NyYXBlIjp0cnVlLCJyYmFjIjp7ImNyZWF0ZSI6dHJ1ZX0sInJlcGxpY2FzIjoxLCJzZWN1cml0eUNvbnRleHQiOnsiZW5hYmxlZCI6dHJ1ZSwiZnNHcm91cCI6NjU1MzQsInJ1bkFzVXNlciI6NjU1MzR9LCJzZXJ2aWNlIjp7ImFubm90YXRpb25zIjp7fSwibG9hZEJhbGFuY2VySVAiOiIiLCJub2RlUG9ydCI6MCwicG9ydCI6ODA4MCwidHlwZSI6IkNsdXN0ZXJJUCJ9LCJzZXJ2aWNlQWNjb3VudCI6eyJjcmVhdGUiOnRydWUsImltYWdlUHVsbFNlY3JldHMiOltdfSwidG9sZXJhdGlvbnMiOltdfSwia3ViZVN0YXRlTWV0cmljcyI6eyJlbmFibGVkIjp0cnVlfSwibm9kZUV4cG9ydGVyIjp7ImVuYWJsZWQiOnRydWUsImV4dHJhQXJncyI6e30sImV4dHJhQ29uZmlnbWFwTW91bnRzIjpbXSwiZXh0cmFIb3N0UGF0aE1vdW50cyI6W10sImhvc3ROZXR3b3JrIjp0cnVlLCJob3N0UElEIjp0cnVlLCJpbWFnZSI6eyJwdWxsUG9saWN5IjoiSWZOb3RQcmVzZW50IiwicmVwb3NpdG9yeSI6InByb20vbm9kZS1leHBvcnRlciIsInRhZyI6InYxLjMuMCJ9LCJuYW1lIjoibm9kZS1leHBvcnRlciIsIm5vZGVTZWxlY3RvciI6e30sInBvZCI6eyJsYWJlbHMiOnt9fSwicG9kQW5ub3RhdGlvbnMiOnt9LCJwb2RTZWN1cml0eVBvbGljeSI6eyJhbm5vdGF0aW9ucyI6e319LCJwcmlvcml0eUNsYXNzTmFtZSI6IiIsInJlc291cmNlcyI6e30sInNlY3VyaXR5Q29udGV4dCI6e30sInNlcnZpY2UiOnsiYW5ub3RhdGlvbnMiOnsicHJvbWV0aGV1cy5pby9zY3JhcGUiOiJ0cnVlIn0sImNsdXN0ZXJJUCI6Ik5vbmUiLCJleHRlcm5hbElQcyI6W10sImhvc3RQb3J0Ijo5MTAwLCJsYWJlbHMiOnt9LCJsb2FkQmFsYW5jZXJJUCI6IiIsImxvYWRCYWxhbmNlclNvdXJjZVJhbmdlcyI6W10sInNlcnZpY2VQb3J0Ijo5MTAwLCJ0eXBlIjoiQ2x1c3RlcklQIn0sInRvbGVyYXRpb25zIjpbXSwidXBkYXRlU3RyYXRlZ3kiOnsidHlwZSI6IlJvbGxpbmdVcGRhdGUifX0sInJiYWMiOnsiY3JlYXRlIjp0cnVlfSwic2VydmVyIjp7ImFmZmluaXR5Ijp7fSwiYWxlcnRtYW5hZ2VycyI6W10sImJhc2VVUkwiOiIiLCJjb25maWdNYXBPdmVycmlkZU5hbWUiOiIiLCJjb25maWdQYXRoIjoiL2V0Yy9jb25maWcvcHJvbWV0aGV1cy55bWwiLCJlbXB0eURpciI6eyJzaXplTGltaXQiOiIifSwiZW5hYmxlZCI6dHJ1ZSwiZW52IjpbXSwiZXh0cmFBcmdzIjp7InF1ZXJ5Lm1heC1jb25jdXJyZW5jeSI6MSwicXVlcnkubWF4LXNhbXBsZXMiOjEwMDAwMDAwMH0sImV4dHJhQ29uZmlnbWFwTW91bnRzIjpbXSwiZXh0cmFGbGFncyI6WyJ3ZWIuZW5hYmxlLWxpZmVjeWNsZSJdLCJleHRyYUhvc3RQYXRoTW91bnRzIjpbXSwiZXh0cmFJbml0Q29udGFpbmVycyI6W10sImV4dHJhU2VjcmV0TW91bnRzIjpbXSwiZXh0cmFWb2x1bWVNb3VudHMiOltdLCJleHRyYVZvbHVtZXMiOltdLCJnbG9iYWwiOnsiZXZhbHVhdGlvbl9pbnRlcnZhbCI6IjFtIiwiZXh0ZXJuYWxfbGFiZWxzIjp7ImNsdXN0ZXJfaWQiOiJjbHVzdGVyLW9uZSJ9LCJzY3JhcGVfaW50ZXJ2YWwiOiIxbSIsInNjcmFwZV90aW1lb3V0IjoiMTBzIn0sImltYWdlIjp7InB1bGxQb2xpY3kiOiJJZk5vdFByZXNlbnQiLCJyZXBvc2l0b3J5IjoicXVheS5pby9wcm9tZXRoZXVzL3Byb21ldGhldXMiLCJ0YWciOiJ2Mi4zNS4wIn0sImxpdmVuZXNzUHJvYmVGYWlsdXJlVGhyZXNob2xkIjozLCJsaXZlbmVzc1Byb2JlSW5pdGlhbERlbGF5IjozMCwibGl2ZW5lc3NQcm9iZVN1Y2Nlc3NUaHJlc2hvbGQiOjEsImxpdmVuZXNzUHJvYmVUaW1lb3V0IjozMCwibmFtZSI6InNlcnZlciIsIm5vZGVTZWxlY3RvciI6e30sInBlcnNpc3RlbnRWb2x1bWUiOnsiYWNjZXNzTW9kZXMiOlsiUmVhZFdyaXRlT25jZSJdLCJhbm5vdGF0aW9ucyI6e30sImVuYWJsZWQiOnRydWUsImV4aXN0aW5nQ2xhaW0iOiIiLCJtb3VudFBhdGgiOiIvZGF0YSIsInNpemUiOiIzMkdpIiwic3ViUGF0aCI6IiJ9LCJwb2RBbm5vdGF0aW9ucyI6e30sInBvZExhYmVscyI6e30sInBvZFNlY3VyaXR5UG9saWN5Ijp7ImFubm90YXRpb25zIjp7fX0sInByZWZpeFVSTCI6IiIsInByaW9yaXR5Q2xhc3NOYW1lIjoiIiwicmVhZGluZXNzUHJvYmVGYWlsdXJlVGhyZXNob2xkIjozLCJyZWFkaW5lc3NQcm9iZUluaXRpYWxEZWxheSI6MzAsInJlYWRpbmVzc1Byb2JlU3VjY2Vzc1RocmVzaG9sZCI6MSwicmVhZGluZXNzUHJvYmVUaW1lb3V0IjozMCwicmVtb3RlUmVhZCI6e30sInJlbW90ZVdyaXRlIjp7fSwicmVwbGljYUNvdW50IjoxLCJyZXNvdXJjZXMiOnt9LCJyZXRlbnRpb24iOiIxNWQiLCJzZWN1cml0eUNvbnRleHQiOnsiZnNHcm91cCI6MTAwMSwicnVuQXNHcm91cCI6MTAwMSwicnVuQXNOb25Sb290Ijp0cnVlLCJydW5Bc1VzZXIiOjEwMDF9LCJzZXJ2aWNlIjp7ImFubm90YXRpb25zIjp7fSwiY2x1c3RlcklQIjoiIiwiZXh0ZXJuYWxJUHMiOltdLCJsYWJlbHMiOnt9LCJsb2FkQmFsYW5jZXJJUCI6IiIsImxvYWRCYWxhbmNlclNvdXJjZVJhbmdlcyI6W10sInNlcnZpY2VQb3J0Ijo4MCwic2Vzc2lvbkFmZmluaXR5IjoiTm9uZSIsInR5cGUiOiJDbHVzdGVySVAifSwic2lkZWNhckNvbnRhaW5lcnMiOm51bGwsInN0cmF0ZWd5Ijp7InR5cGUiOiJSZWNyZWF0ZSJ9LCJ0ZXJtaW5hdGlvbkdyYWNlUGVyaW9kU2Vjb25kcyI6MzAwLCJ0b2xlcmF0aW9ucyI6W119LCJzZXJ2ZXJGaWxlcyI6eyJhbGVydGluZ19ydWxlcy55bWwiOnt9LCJhbGVydHMiOnt9LCJwcm9tZXRoZXVzLnltbCI6eyJydWxlX2ZpbGVzIjpbIi9ldGMvY29uZmlnL3JlY29yZGluZ19ydWxlcy55bWwiLCIvZXRjL2NvbmZpZy9hbGVydGluZ19ydWxlcy55bWwiLCIvZXRjL2NvbmZpZy9ydWxlcyIsIi9ldGMvY29uZmlnL2FsZXJ0cyJdLCJzY3JhcGVfY29uZmlncyI6W3siam9iX25hbWUiOiJwcm9tZXRoZXVzIiwic3RhdGljX2NvbmZpZ3MiOlt7InRhcmdldHMiOlsibG9jYWxob3N0OjkwOTAiXX1dfSx7ImJlYXJlcl90b2tlbl9maWxlIjoiL3Zhci9ydW4vc2VjcmV0cy9rdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3Rva2VuIiwiam9iX25hbWUiOiJrdWJlcm5ldGVzLW5vZGVzLWNhZHZpc29yIiwia3ViZXJuZXRlc19zZF9jb25maWdzIjpbeyJyb2xlIjoibm9kZSJ9XSwibWV0cmljX3JlbGFiZWxfY29uZmlncyI6W3siYWN0aW9uIjoia2VlcCIsInJlZ2V4IjoiKGNvbnRhaW5lcl9jcHVfdXNhZ2Vfc2Vjb25kc190b3RhbHxjb250YWluZXJfbWVtb3J5X3dvcmtpbmdfc2V0X2J5dGVzfGNvbnRhaW5lcl9uZXR3b3JrX3JlY2VpdmVfZXJyb3JzX3RvdGFsfGNvbnRhaW5lcl9uZXR3b3JrX3RyYW5zbWl0X2Vycm9yc190b3RhbHxjb250YWluZXJfbmV0d29ya19yZWNlaXZlX3BhY2tldHNfZHJvcHBlZF90b3RhbHxjb250YWluZXJfbmV0d29ya190cmFuc21pdF9wYWNrZXRzX2Ryb3BwZWRfdG90YWx8Y29udGFpbmVyX21lbW9yeV91c2FnZV9ieXRlc3xjb250YWluZXJfY3B1X2Nmc190aHJvdHRsZWRfcGVyaW9kc190b3RhbHxjb250YWluZXJfY3B1X2Nmc19wZXJpb2RzX3RvdGFsfGNvbnRhaW5lcl9mc191c2FnZV9ieXRlc3xjb250YWluZXJfZnNfbGltaXRfYnl0ZXN8Y29udGFpbmVyX2NwdV9jZnNfcGVyaW9kc190b3RhbHxjb250YWluZXJfZnNfaW5vZGVzX2ZyZWV8Y29udGFpbmVyX2ZzX2lub2Rlc190b3RhbHxjb250YWluZXJfZnNfdXNhZ2VfYnl0ZXN8Y29udGFpbmVyX2ZzX2xpbWl0X2J5dGVzfGNvbnRhaW5lcl9jcHVfY2ZzX3Rocm90dGxlZF9wZXJpb2RzX3RvdGFsfGNvbnRhaW5lcl9jcHVfY2ZzX3BlcmlvZHNfdG90YWx8Y29udGFpbmVyX25ldHdvcmtfcmVjZWl2ZV9ieXRlc190b3RhbHxjb250YWluZXJfbmV0d29ya190cmFuc21pdF9ieXRlc190b3RhbHxjb250YWluZXJfZnNfaW5vZGVzX2ZyZWV8Y29udGFpbmVyX2ZzX2lub2Rlc190b3RhbHxjb250YWluZXJfZnNfdXNhZ2VfYnl0ZXN8Y29udGFpbmVyX2ZzX2xpbWl0X2J5dGVzfGNvbnRhaW5lcl9zcGVjX2NwdV9zaGFyZXN8Y29udGFpbmVyX3NwZWNfbWVtb3J5X2xpbWl0X2J5dGVzfGNvbnRhaW5lcl9uZXR3b3JrX3JlY2VpdmVfYnl0ZXNfdG90YWx8Y29udGFpbmVyX25ldHdvcmtfdHJhbnNtaXRfYnl0ZXNfdG90YWx8Y29udGFpbmVyX2ZzX3JlYWRzX2J5dGVzX3RvdGFsfGNvbnRhaW5lcl9uZXR3b3JrX3JlY2VpdmVfYnl0ZXNfdG90YWx8Y29udGFpbmVyX2ZzX3dyaXRlc19ieXRlc190b3RhbHxjb250YWluZXJfZnNfcmVhZHNfYnl0ZXNfdG90YWx8Y2Fkdmlzb3JfdmVyc2lvbl9pbmZvfGt1YmVjb3N0X3B2X2luZm8pIiwic291cmNlX2xhYmVscyI6WyJfX25hbWVfXyJdfSx7ImFjdGlvbiI6InJlcGxhY2UiLCJyZWdleCI6IiguKykiLCJzb3VyY2VfbGFiZWxzIjpbImNvbnRhaW5lciJdLCJ0YXJnZXRfbGFiZWwiOiJjb250YWluZXJfbmFtZSJ9LHsiYWN0aW9uIjoicmVwbGFjZSIsInJlZ2V4IjoiKC4rKSIsInNvdXJjZV9sYWJlbHMiOlsicG9kIl0sInRhcmdldF9sYWJlbCI6InBvZF9uYW1lIn1dLCJyZWxhYmVsX2NvbmZpZ3MiOlt7ImFjdGlvbiI6ImxhYmVsbWFwIiwicmVnZXgiOiJfX21ldGFfa3ViZXJuZXRlc19ub2RlX2xhYmVsXyguKykifSx7InJlcGxhY2VtZW50Ijoia3ViZXJuZXRlcy5kZWZhdWx0LnN2Yzo0NDMiLCJ0YXJnZXRfbGFiZWwiOiJfX2FkZHJlc3NfXyJ9LHsicmVnZXgiOiIoLispIiwicmVwbGFjZW1lbnQiOiIvYXBpL3YxL25vZGVzLyQxL3Byb3h5L21ldHJpY3MvY2Fkdmlzb3IiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX25vZGVfbmFtZSJdLCJ0YXJnZXRfbGFiZWwiOiJfX21ldHJpY3NfcGF0aF9fIn1dLCJzY2hlbWUiOiJodHRwcyIsInRsc19jb25maWciOnsiY2FfZmlsZSI6Ii92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9jYS5jcnQiLCJpbnNlY3VyZV9za2lwX3ZlcmlmeSI6dHJ1ZX19LHsiam9iX25hbWUiOiJrdWJlcm5ldGVzLXNlcnZpY2UtZW5kcG9pbnRzIiwia3ViZXJuZXRlc19zZF9jb25maWdzIjpbeyJyb2xlIjoiZW5kcG9pbnRzIn1dLCJtZXRyaWNfcmVsYWJlbF9jb25maWdzIjpbeyJhY3Rpb24iOiJrZWVwIiwicmVnZXgiOiIoY29udGFpbmVyX2NwdV9hbGxvY2F0aW9ufGNvbnRhaW5lcl9jcHVfdXNhZ2Vfc2Vjb25kc190b3RhbHxjb250YWluZXJfZnNfbGltaXRfYnl0ZXN8Y29udGFpbmVyX2ZzX3dyaXRlc19ieXRlc190b3RhbHxjb250YWluZXJfZ3B1X2FsbG9jYXRpb258Y29udGFpbmVyX21lbW9yeV9hbGxvY2F0aW9uX2J5dGVzfGNvbnRhaW5lcl9tZW1vcnlfdXNhZ2VfYnl0ZXN8Y29udGFpbmVyX21lbW9yeV93b3JraW5nX3NldF9ieXRlc3xjb250YWluZXJfbmV0d29ya19yZWNlaXZlX2J5dGVzX3RvdGFsfGNvbnRhaW5lcl9uZXR3b3JrX3RyYW5zbWl0X2J5dGVzX3RvdGFsfERDR01fRklfREVWX0dQVV9VVElMfGRlcGxveW1lbnRfbWF0Y2hfbGFiZWxzfGt1YmVfZGFlbW9uc2V0X3N0YXR1c19kZXNpcmVkX251bWJlcl9zY2hlZHVsZWR8a3ViZV9kYWVtb25zZXRfc3RhdHVzX251bWJlcl9yZWFkeXxrdWJlX2RlcGxveW1lbnRfc3BlY19yZXBsaWNhc3xrdWJlX2RlcGxveW1lbnRfc3RhdHVzX3JlcGxpY2FzfGt1YmVfZGVwbG95bWVudF9zdGF0dXNfcmVwbGljYXNfYXZhaWxhYmxlfGt1YmVfam9iX3N0YXR1c19mYWlsZWR8a3ViZV9uYW1lc3BhY2VfYW5ub3RhdGlvbnN8a3ViZV9uYW1lc3BhY2VfbGFiZWxzfGt1YmVfbm9kZV9pbmZvfGt1YmVfbm9kZV9sYWJlbHN8a3ViZV9ub2RlX3N0YXR1c19hbGxvY2F0YWJsZXxrdWJlX25vZGVfc3RhdHVzX2FsbG9jYXRhYmxlX2NwdV9jb3Jlc3xrdWJlX25vZGVfc3RhdHVzX2FsbG9jYXRhYmxlX21lbW9yeV9ieXRlc3xrdWJlX25vZGVfc3RhdHVzX2NhcGFjaXR5fGt1YmVfbm9kZV9zdGF0dXNfY2FwYWNpdHlfY3B1X2NvcmVzfGt1YmVfbm9kZV9zdGF0dXNfY2FwYWNpdHlfbWVtb3J5X2J5dGVzfGt1YmVfbm9kZV9zdGF0dXNfY29uZGl0aW9ufGt1YmVfcGVyc2lzdGVudHZvbHVtZV9jYXBhY2l0eV9ieXRlc3xrdWJlX3BlcnNpc3RlbnR2b2x1bWVfc3RhdHVzX3BoYXNlfGt1YmVfcGVyc2lzdGVudHZvbHVtZWNsYWltX2luZm98a3ViZV9wZXJzaXN0ZW50dm9sdW1lY2xhaW1fcmVzb3VyY2VfcmVxdWVzdHNfc3RvcmFnZV9ieXRlc3xrdWJlX3BvZF9jb250YWluZXJfaW5mb3xrdWJlX3BvZF9jb250YWluZXJfcmVzb3VyY2VfbGltaXRzfGt1YmVfcG9kX2NvbnRhaW5lcl9yZXNvdXJjZV9saW1pdHNfY3B1X2NvcmVzfGt1YmVfcG9kX2NvbnRhaW5lcl9yZXNvdXJjZV9saW1pdHNfbWVtb3J5X2J5dGVzfGt1YmVfcG9kX2NvbnRhaW5lcl9yZXNvdXJjZV9yZXF1ZXN0c3xrdWJlX3BvZF9jb250YWluZXJfcmVzb3VyY2VfcmVxdWVzdHNfY3B1X2NvcmVzfGt1YmVfcG9kX2NvbnRhaW5lcl9yZXNvdXJjZV9yZXF1ZXN0c19tZW1vcnlfYnl0ZXN8a3ViZV9wb2RfY29udGFpbmVyX3N0YXR1c19yZXN0YXJ0c190b3RhbHxrdWJlX3BvZF9jb250YWluZXJfc3RhdHVzX3J1bm5pbmd8a3ViZV9wb2RfY29udGFpbmVyX3N0YXR1c190ZXJtaW5hdGVkX3JlYXNvbnxrdWJlX3BvZF9sYWJlbHN8a3ViZV9wb2Rfb3duZXJ8a3ViZV9wb2Rfc3RhdHVzX3BoYXNlfGt1YmVfcmVwbGljYXNldF9vd25lcnxrdWJlX3N0YXRlZnVsc2V0X3JlcGxpY2FzfGt1YmVfc3RhdGVmdWxzZXRfc3RhdHVzX3JlcGxpY2FzfGt1YmVjb3N0X2NsdXN0ZXJfaW5mb3xrdWJlY29zdF9jbHVzdGVyX21hbmFnZW1lbnRfY29zdHxrdWJlY29zdF9jbHVzdGVyX21lbW9yeV93b3JraW5nX3NldF9ieXRlc3xrdWJlY29zdF9sb2FkX2JhbGFuY2VyX2Nvc3R8a3ViZWNvc3RfbmV0d29ya19pbnRlcm5ldF9lZ3Jlc3NfY29zdHxrdWJlY29zdF9uZXR3b3JrX3JlZ2lvbl9lZ3Jlc3NfY29zdHxrdWJlY29zdF9uZXR3b3JrX3pvbmVfZWdyZXNzX2Nvc3R8a3ViZWNvc3Rfbm9kZV9pc19zcG90fGt1YmVjb3N0X3BvZF9uZXR3b3JrX2VncmVzc19ieXRlc190b3RhbHxub2RlX2NwdV9ob3VybHlfY29zdHxub2RlX2NwdV9zZWNvbmRzX3RvdGFsfG5vZGVfZGlza19yZWFkc19jb21wbGV0ZWR8bm9kZV9kaXNrX3JlYWRzX2NvbXBsZXRlZF90b3RhbHxub2RlX2Rpc2tfd3JpdGVzX2NvbXBsZXRlZHxub2RlX2Rpc2tfd3JpdGVzX2NvbXBsZXRlZF90b3RhbHxub2RlX2ZpbGVzeXN0ZW1fZGV2aWNlX2Vycm9yfG5vZGVfZ3B1X2NvdW50fG5vZGVfZ3B1X2hvdXJseV9jb3N0fG5vZGVfbWVtb3J5X0J1ZmZlcnNfYnl0ZXN8bm9kZV9tZW1vcnlfQ2FjaGVkX2J5dGVzfG5vZGVfbWVtb3J5X01lbUF2YWlsYWJsZV9ieXRlc3xub2RlX21lbW9yeV9NZW1GcmVlX2J5dGVzfG5vZGVfbWVtb3J5X01lbVRvdGFsX2J5dGVzfG5vZGVfbmV0d29ya190cmFuc21pdF9ieXRlc190b3RhbHxub2RlX3JhbV9ob3VybHlfY29zdHxub2RlX3RvdGFsX2hvdXJseV9jb3N0fHBvZF9wdmNfYWxsb2NhdGlvbnxwdl9ob3VybHlfY29zdHxzZXJ2aWNlX3NlbGVjdG9yX2xhYmVsc3xzdGF0ZWZ1bFNldF9tYXRjaF9sYWJlbHN8a3ViZWNvc3RfcHZfaW5mb3x1cCkiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbmFtZV9fIl19XSwicmVsYWJlbF9jb25maWdzIjpbeyJhY3Rpb24iOiJrZWVwIiwicmVnZXgiOnRydWUsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9hbm5vdGF0aW9uX3Byb21ldGhldXNfaW9fc2NyYXBlIl19LHsiYWN0aW9uIjoicmVwbGFjZSIsInJlZ2V4IjoiKGh0dHBzPykiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfYW5ub3RhdGlvbl9wcm9tZXRoZXVzX2lvX3NjaGVtZSJdLCJ0YXJnZXRfbGFiZWwiOiJfX3NjaGVtZV9fIn0seyJhY3Rpb24iOiJyZXBsYWNlIiwicmVnZXgiOiIoLispIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX2Fubm90YXRpb25fcHJvbWV0aGV1c19pb19wYXRoIl0sInRhcmdldF9sYWJlbCI6Il9fbWV0cmljc19wYXRoX18ifSx7ImFjdGlvbiI6InJlcGxhY2UiLCJyZWdleCI6IihbXjpdKykoPzo6XFxkKyk/OyhcXGQrKSIsInJlcGxhY2VtZW50IjoiJDE6JDIiLCJzb3VyY2VfbGFiZWxzIjpbIl9fYWRkcmVzc19fIiwiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9hbm5vdGF0aW9uX3Byb21ldGhldXNfaW9fcG9ydCJdLCJ0YXJnZXRfbGFiZWwiOiJfX2FkZHJlc3NfXyJ9LHsiYWN0aW9uIjoibGFiZWxtYXAiLCJyZWdleCI6Il9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfbGFiZWxfKC4rKSJ9LHsiYWN0aW9uIjoicmVwbGFjZSIsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfbmFtZXNwYWNlIl0sInRhcmdldF9sYWJlbCI6Imt1YmVybmV0ZXNfbmFtZXNwYWNlIn0seyJhY3Rpb24iOiJyZXBsYWNlIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX25hbWUiXSwidGFyZ2V0X2xhYmVsIjoia3ViZXJuZXRlc19uYW1lIn0seyJhY3Rpb24iOiJyZXBsYWNlIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19wb2Rfbm9kZV9uYW1lIl0sInRhcmdldF9sYWJlbCI6Imt1YmVybmV0ZXNfbm9kZSJ9XX0seyJqb2JfbmFtZSI6Imt1YmVybmV0ZXMtc2VydmljZS1lbmRwb2ludHMtc2xvdyIsImt1YmVybmV0ZXNfc2RfY29uZmlncyI6W3sicm9sZSI6ImVuZHBvaW50cyJ9XSwicmVsYWJlbF9jb25maWdzIjpbeyJhY3Rpb24iOiJrZWVwIiwicmVnZXgiOnRydWUsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9hbm5vdGF0aW9uX3Byb21ldGhldXNfaW9fc2NyYXBlX3Nsb3ciXX0seyJhY3Rpb24iOiJyZXBsYWNlIiwicmVnZXgiOiIoaHR0cHM/KSIsInNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9hbm5vdGF0aW9uX3Byb21ldGhldXNfaW9fc2NoZW1lIl0sInRhcmdldF9sYWJlbCI6Il9fc2NoZW1lX18ifSx7ImFjdGlvbiI6InJlcGxhY2UiLCJyZWdleCI6IiguKykiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfYW5ub3RhdGlvbl9wcm9tZXRoZXVzX2lvX3BhdGgiXSwidGFyZ2V0X2xhYmVsIjoiX19tZXRyaWNzX3BhdGhfXyJ9LHsiYWN0aW9uIjoicmVwbGFjZSIsInJlZ2V4IjoiKFteOl0rKSg/OjpcXGQrKT87KFxcZCspIiwicmVwbGFjZW1lbnQiOiIkMTokMiIsInNvdXJjZV9sYWJlbHMiOlsiX19hZGRyZXNzX18iLCJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX2Fubm90YXRpb25fcHJvbWV0aGV1c19pb19wb3J0Il0sInRhcmdldF9sYWJlbCI6Il9fYWRkcmVzc19fIn0seyJhY3Rpb24iOiJsYWJlbG1hcCIsInJlZ2V4IjoiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9sYWJlbF8oLispIn0seyJhY3Rpb24iOiJyZXBsYWNlIiwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19uYW1lc3BhY2UiXSwidGFyZ2V0X2xhYmVsIjoia3ViZXJuZXRlc19uYW1lc3BhY2UifSx7ImFjdGlvbiI6InJlcGxhY2UiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfbmFtZSJdLCJ0YXJnZXRfbGFiZWwiOiJrdWJlcm5ldGVzX25hbWUifSx7ImFjdGlvbiI6InJlcGxhY2UiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3BvZF9ub2RlX25hbWUiXSwidGFyZ2V0X2xhYmVsIjoia3ViZXJuZXRlc19ub2RlIn1dLCJzY3JhcGVfaW50ZXJ2YWwiOiI1bSIsInNjcmFwZV90aW1lb3V0IjoiMzBzIn0seyJob25vcl9sYWJlbHMiOnRydWUsImpvYl9uYW1lIjoicHJvbWV0aGV1cy1wdXNoZ2F0ZXdheSIsImt1YmVybmV0ZXNfc2RfY29uZmlncyI6W3sicm9sZSI6InNlcnZpY2UifV0sInJlbGFiZWxfY29uZmlncyI6W3siYWN0aW9uIjoia2VlcCIsInJlZ2V4IjoicHVzaGdhdGV3YXkiLCJzb3VyY2VfbGFiZWxzIjpbIl9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfYW5ub3RhdGlvbl9wcm9tZXRoZXVzX2lvX3Byb2JlIl19XX0seyJqb2JfbmFtZSI6Imt1YmVybmV0ZXMtc2VydmljZXMiLCJrdWJlcm5ldGVzX3NkX2NvbmZpZ3MiOlt7InJvbGUiOiJzZXJ2aWNlIn1dLCJtZXRyaWNzX3BhdGgiOiIvcHJvYmUiLCJwYXJhbXMiOnsibW9kdWxlIjpbImh0dHBfMnh4Il19LCJyZWxhYmVsX2NvbmZpZ3MiOlt7ImFjdGlvbiI6ImtlZXAiLCJyZWdleCI6dHJ1ZSwic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19zZXJ2aWNlX2Fubm90YXRpb25fcHJvbWV0aGV1c19pb19wcm9iZSJdfSx7InNvdXJjZV9sYWJlbHMiOlsiX19hZGRyZXNzX18iXSwidGFyZ2V0X2xhYmVsIjoiX19wYXJhbV90YXJnZXQifSx7InJlcGxhY2VtZW50IjoiYmxhY2tib3giLCJ0YXJnZXRfbGFiZWwiOiJfX2FkZHJlc3NfXyJ9LHsic291cmNlX2xhYmVscyI6WyJfX3BhcmFtX3RhcmdldCJdLCJ0YXJnZXRfbGFiZWwiOiJpbnN0YW5jZSJ9LHsiYWN0aW9uIjoibGFiZWxtYXAiLCJyZWdleCI6Il9fbWV0YV9rdWJlcm5ldGVzX3NlcnZpY2VfbGFiZWxfKC4rKSJ9LHsic291cmNlX2xhYmVscyI6WyJfX21ldGFfa3ViZXJuZXRlc19uYW1lc3BhY2UiXSwidGFyZ2V0X2xhYmVsIjoia3ViZXJuZXRlc19uYW1lc3BhY2UifSx7InNvdXJjZV9sYWJlbHMiOlsiX19tZXRhX2t1YmVybmV0ZXNfc2VydmljZV9uYW1lIl0sInRhcmdldF9sYWJlbCI6Imt1YmVybmV0ZXNfbmFtZSJ9XX1dfSwicmVjb3JkaW5nX3J1bGVzLnltbCI6e30sInJ1bGVzIjp7Imdyb3VwcyI6W3sibmFtZSI6IkNQVSIsInJ1bGVzIjpbeyJleHByIjoic3VtKHJhdGUoY29udGFpbmVyX2NwdV91c2FnZV9zZWNvbmRzX3RvdGFse2NvbnRhaW5lcl9uYW1lIT1cIlwifVs1bV0pKSIsInJlY29yZCI6ImNsdXN0ZXI6Y3B1X3VzYWdlOnJhdGU1bSJ9LHsiZXhwciI6InJhdGUoY29udGFpbmVyX2NwdV91c2FnZV9zZWNvbmRzX3RvdGFse2NvbnRhaW5lcl9uYW1lIT1cIlwifVs1bV0pIiwicmVjb3JkIjoiY2x1c3RlcjpjcHVfdXNhZ2Vfbm9zdW06cmF0ZTVtIn0seyJleHByIjoiYXZnKGlyYXRlKGNvbnRhaW5lcl9jcHVfdXNhZ2Vfc2Vjb25kc190b3RhbHtjb250YWluZXJfbmFtZSE9XCJQT0RcIiwgY29udGFpbmVyX25hbWUhPVwiXCJ9WzVtXSkpIGJ5IChjb250YWluZXJfbmFtZSxwb2RfbmFtZSxuYW1lc3BhY2UpIiwicmVjb3JkIjoia3ViZWNvc3RfY29udGFpbmVyX2NwdV91c2FnZV9pcmF0ZSJ9LHsiZXhwciI6InN1bShjb250YWluZXJfbWVtb3J5X3dvcmtpbmdfc2V0X2J5dGVze2NvbnRhaW5lcl9uYW1lIT1cIlBPRFwiLGNvbnRhaW5lcl9uYW1lIT1cIlwifSkgYnkgKGNvbnRhaW5lcl9uYW1lLHBvZF9uYW1lLG5hbWVzcGFjZSkiLCJyZWNvcmQiOiJrdWJlY29zdF9jb250YWluZXJfbWVtb3J5X3dvcmtpbmdfc2V0X2J5dGVzIn0seyJleHByIjoic3VtKGNvbnRhaW5lcl9tZW1vcnlfd29ya2luZ19zZXRfYnl0ZXN7Y29udGFpbmVyX25hbWUhPVwiUE9EXCIsY29udGFpbmVyX25hbWUhPVwiXCJ9KSIsInJlY29yZCI6Imt1YmVjb3N0X2NsdXN0ZXJfbWVtb3J5X3dvcmtpbmdfc2V0X2J5dGVzIn1dfSx7Im5hbWUiOiJTYXZpbmdzIiwicnVsZXMiOlt7ImV4cHIiOiJzdW0oYXZnKGt1YmVfcG9kX293bmVye293bmVyX2tpbmQhPVwiRGFlbW9uU2V0XCJ9KSBieSAocG9kKSAqIHN1bShjb250YWluZXJfY3B1X2FsbG9jYXRpb24pIGJ5IChwb2QpKSIsImxhYmVscyI6eyJkYWVtb25zZXQiOiJmYWxzZSJ9LCJyZWNvcmQiOiJrdWJlY29zdF9zYXZpbmdzX2NwdV9hbGxvY2F0aW9uIn0seyJleHByIjoic3VtKGF2ZyhrdWJlX3BvZF9vd25lcntvd25lcl9raW5kPVwiRGFlbW9uU2V0XCJ9KSBieSAocG9kKSAqIHN1bShjb250YWluZXJfY3B1X2FsbG9jYXRpb24pIGJ5IChwb2QpKSAvIHN1bShrdWJlX25vZGVfaW5mbykiLCJsYWJlbHMiOnsiZGFlbW9uc2V0IjoidHJ1ZSJ9LCJyZWNvcmQiOiJrdWJlY29zdF9zYXZpbmdzX2NwdV9hbGxvY2F0aW9uIn0seyJleHByIjoic3VtKGF2ZyhrdWJlX3BvZF9vd25lcntvd25lcl9raW5kIT1cIkRhZW1vblNldFwifSkgYnkgKHBvZCkgKiBzdW0oY29udGFpbmVyX21lbW9yeV9hbGxvY2F0aW9uX2J5dGVzKSBieSAocG9kKSkiLCJsYWJlbHMiOnsiZGFlbW9uc2V0IjoiZmFsc2UifSwicmVjb3JkIjoia3ViZWNvc3Rfc2F2aW5nc19tZW1vcnlfYWxsb2NhdGlvbl9ieXRlcyJ9LHsiZXhwciI6InN1bShhdmcoa3ViZV9wb2Rfb3duZXJ7b3duZXJfa2luZD1cIkRhZW1vblNldFwifSkgYnkgKHBvZCkgKiBzdW0oY29udGFpbmVyX21lbW9yeV9hbGxvY2F0aW9uX2J5dGVzKSBieSAocG9kKSkgLyBzdW0oa3ViZV9ub2RlX2luZm8pIiwibGFiZWxzIjp7ImRhZW1vbnNldCI6InRydWUifSwicmVjb3JkIjoia3ViZWNvc3Rfc2F2aW5nc19tZW1vcnlfYWxsb2NhdGlvbl9ieXRlcyJ9XX1dfX0sInNlcnZpY2VBY2NvdW50cyI6eyJhbGVydG1hbmFnZXIiOnsiY3JlYXRlIjp0cnVlfSwibm9kZUV4cG9ydGVyIjp7ImNyZWF0ZSI6dHJ1ZX0sInB1c2hnYXRld2F5Ijp7ImNyZWF0ZSI6dHJ1ZX0sInNlcnZlciI6eyJjcmVhdGUiOnRydWV9fX0sInJlbW90ZVdyaXRlIjp7fSwicmVwb3J0aW5nIjp7ImVycm9yUmVwb3J0aW5nIjp0cnVlLCJsb2dDb2xsZWN0aW9uIjp0cnVlLCJwcm9kdWN0QW5hbHl0aWNzIjp0cnVlLCJ2YWx1ZXNSZXBvcnRpbmciOnRydWV9LCJzZXJ2aWNlIjp7ImFubm90YXRpb25zIjp7fSwibGFiZWxzIjp7fSwicG9ydCI6OTA5MCwidGFyZ2V0UG9ydCI6OTA5MCwidHlwZSI6IkNsdXN0ZXJJUCJ9LCJzZXJ2aWNlQWNjb3VudCI6eyJhbm5vdGF0aW9ucyI6e30sImNyZWF0ZSI6dHJ1ZX0sInNpZ1Y0UHJveHkiOnsiZXh0cmFFbnYiOm51bGwsImhvc3QiOiJhcHMtd29ya3NwYWNlcy51cy13ZXN0LTIuYW1hem9uYXdzLmNvbSIsImltYWdlIjoicHVibGljLmVjci5hd3MvYXdzLW9ic2VydmFiaWxpdHkvYXdzLXNpZ3Y0LXByb3h5OmxhdGVzdCIsImltYWdlUHVsbFBvbGljeSI6IkFsd2F5cyIsIm5hbWUiOiJhcHMiLCJwb3J0Ijo4MDA1LCJyZWdpb24iOiJ1cy13ZXN0LTIifSwic3VwcG9ydE5GUyI6ZmFsc2UsInRvbGVyYXRpb25zIjpbXX0=
+            - name: READ_ONLY
+              value: "false"
+            - name: PROMETHEUS_SERVER_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: kubecost-cost-analyzer
+                  key: prometheus-server-endpoint
+            - name: CLOUD_PROVIDER_API_KEY
+              value: "AIzaSyDXQPG_MHUEy9neR7stolq6l0ujXmjJlvk" # The GCP Pricing API requires a key.
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/configs/key.json
+            - name: CONFIG_PATH
+              value: /var/configs/
+            - name: DB_PATH
+              value: /var/db/
+            - name: CLUSTER_PROFILE
+              value: production
+            - name: REMOTE_WRITE_PASSWORD
+              value: admin
+            - name: EMIT_POD_ANNOTATIONS_METRIC
+              value: "false"
+            - name: EMIT_NAMESPACE_ANNOTATIONS_METRIC
+              value: "false"
+            - name: EMIT_KSM_V1_METRICS
+              value: "true"
+            - name: EMIT_KSM_V1_METRICS_ONLY # ONLY emit KSM v1 metrics that do not exist in KSM 2 by default
+              value: "false"
+            - name: LOG_COLLECTION_ENABLED
+              value: "true"
+            - name: PRODUCT_ANALYTICS_ENABLED
+              value: "true"
+            - name: ERROR_REPORTING_ENABLED
+              value: "true"
+            - name: VALUES_REPORTING_ENABLED
+              value: "true"
+            - name: SENTRY_DSN
+              value: "https://71964476292e4087af8d5072afe43abd@o394722.ingest.sentry.io/5245431"
+            - name: LEGACY_EXTERNAL_API_DISABLED
+              value: "false"
+            - name: OUT_OF_CLUSTER_PROM_METRICS_ENABLED
+              value: "false"
+            - name: CACHE_WARMING_ENABLED
+              value: "false"
+            - name: SAVINGS_CACHE_WARMING_ENABLED
+              value: "true"
+            - name: ETL_ENABLED
+              value: "true"
+            - name: ETL_TO_DISK_ENABLED
+              value: "true"
+            - name: ETL_STORE_READ_ONLY
+              value: "false"
+            - name : ETL_CLOUD_USAGE_ENABLED
+              value: "true"
+            - name: CLOUD_ASSETS_EXCLUDE_PROVIDER_ID
+              value: "false"
+            - name: ETL_CLOUD_REFRESH_RATE_HOURS
+              value: "6"
+            - name: ETL_CLOUD_QUERY_WINDOW_DAYS
+              value: "7"
+            - name: ETL_CLOUD_RUN_WINDOW_DAYS
+              value: "3"
+            - name: ETL_RESOLUTION_SECONDS
+              value: "300"
+            - name: ETL_MAX_PROMETHEUS_QUERY_DURATION_MINUTES
+              value: "1440"
+            - name: ETL_DAILY_STORE_DURATION_DAYS
+              value: "91"
+            - name: ETL_HOURLY_STORE_DURATION_HOURS
+              value: "49"
+            - name: ETL_FILE_STORE_ENABLED
+              value: "true"
+            - name: ETL_ASSET_RECONCILIATION_ENABLED
+              value: "true"
+            - name: ETL_USE_UNBLENDED_COST
+              value: "false"
+            - name: RECONCILE_NETWORK
+              value: "true"
+            - name: KUBECOST_METRICS_POD_ENABLED
+              value: "false"
+            - name: PV_ENABLED
+              value: "true"
+            - name: MAX_QUERY_CONCURRENCY
+              value: "5"
+            - name: UTC_OFFSET
+              value:
+            - name: CLUSTER_ID
+              value: cluster-one
+            - name: SQL_ADDRESS
+              value: pgprometheus
+            - name: RELEASE_NAME
+              value: kubecost
+            - name: KUBECOST_NAMESPACE
+              value: kubecost
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: KUBECOST_TOKEN
+              valueFrom:
+                configMapKeyRef:
+                  name: kubecost-cost-analyzer
+                  key: kubecost-token
+        - image: gcr.io/kubecost1/frontend:prod-1.97.0
+
+          env:
+            - name: GET_HOSTS_FROM
+              value: dns
+          name: cost-analyzer-frontend
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/
+          resources:
+            requests:
+              cpu: 10m
+              memory: 55Mi
+          imagePullPolicy: Always
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 200

--- a/infrastructure/monitoring/helm_manifests/loki.yaml
+++ b/infrastructure/monitoring/helm_manifests/loki.yaml
@@ -1,0 +1,109 @@
+test_pod:
+  image: bats/bats:v1.1.0
+  pullPolicy: IfNotPresent
+
+loki:
+  enabled: true
+  isDefault: true
+  url: http://{{(include "loki.serviceName" .)}}:{{ .Values.loki.service.port }}
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+  livenessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+  datasource:
+    jsonData: {}
+    uid: ""
+
+
+promtail:
+  enabled: true
+  config:
+    logLevel: info
+    serverPort: 3101
+    clients:
+      - url: http://{{ .Release.Name }}:3100/loki/api/v1/push
+
+fluent-bit:
+  enabled: false
+
+grafana:
+  enabled: false
+  sidecar:
+    datasources:
+      enabled: true
+      maxLines: 1000
+  image:
+    tag: 8.3.5
+
+prometheus:
+  enabled: false
+  isDefault: false
+  url: http://{{ include "prometheus.fullname" .}}:{{ .Values.prometheus.server.service.servicePort }}{{ .Values.prometheus.server.prefixURL }}
+  datasource:
+    jsonData: {}
+
+filebeat:
+  enabled: false
+  filebeatConfig:
+    filebeat.yml: |
+      # logging.level: debug
+      filebeat.inputs:
+      - type: container
+        paths:
+          - /var/log/containers/*.log
+        processors:
+        - add_kubernetes_metadata:
+            host: ${NODE_NAME}
+            matchers:
+            - logs_path:
+                logs_path: "/var/log/containers/"
+      output.logstash:
+        hosts: ["logstash-loki:5044"]
+
+logstash:
+  enabled: false
+  image: grafana/logstash-output-loki
+  imageTag: 1.0.1
+  filters:
+    main: |-
+      filter {
+        if [kubernetes] {
+          mutate {
+            add_field => {
+              "container_name" => "%{[kubernetes][container][name]}"
+              "namespace" => "%{[kubernetes][namespace]}"
+              "pod" => "%{[kubernetes][pod][name]}"
+            }
+            replace => { "host" => "%{[kubernetes][node][name]}"}
+          }
+        }
+        mutate {
+          remove_field => ["tags"]
+        }
+      }
+  outputs:
+    main: |-
+      output {
+        loki {
+          url => "http://loki:3100/loki/api/v1/push"
+          #username => "test"
+          #password => "test"
+        }
+        # stdout { codec => rubydebug }
+      }
+
+# proxy is currently only used by loki test pod
+# Note: If http_proxy/https_proxy are set, then no_proxy should include the
+# loki service name, so that tests are able to communicate with the loki
+# service.
+proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+


### PR DESCRIPTION
Because the helm tool makes the deployment of full application stacks much easier, we should use them in some deployments. A directory was added to include all helm charts used with values. Loki (with promtail in the cart grafana/loki-stack) is used to get all logs from applications and send them to grafana as a data source, while Kubecost monitors the full cost of the custer in detail.