### PR TITLE
solve small issues for correct test pipeline

### DIFF
--- a/.circleci/locust.sh
+++ b/.circleci/locust.sh
@@ -71,5 +71,5 @@ sed -i 's/^\(locust_[^ ]*\) .*/\1 0/g' locust.metrics
 push_to_s3
 
 sleep 30
-kubectl_run delete -f apps/locust-metrics-distributor/kubernetes/
+kubectl_run delete job locust-metrics-distributor -n monitoring
 

--- a/apps/locust-metrics-distributor/kubernetes/values.yaml
+++ b/apps/locust-metrics-distributor/kubernetes/values.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: locust-metrics-distributor
-        image: diegopedroso/locust-metrics-distributor:CIRCLE_TAG_REPLACE
+        image: diegopedroso/locust-metrics-distributor:20230602.01
         envFrom:
         - secretRef:
             name: locust-distributor-secrets

--- a/infrastructure/terraform/aws/iam/vars/prod.tfvars
+++ b/infrastructure/terraform/aws/iam/vars/prod.tfvars
@@ -9,4 +9,4 @@ username_read_only  = []
 bucket_states_name  = "lasdpc-terraform-states"
 bucket_gatling_name = "lasdpc-gatling-results"
 bucket_locust_name  = "lasdpc-locust-results"
-oidc_provider  = "https://oidc.eks.us-east-1.amazonaws.com/id/D24C5025164533C85B138C68071B5515"
+oidc_provider  = "oidc.eks.us-east-1.amazonaws.com/id/D24C5025164533C85B138C68071B5515"


### PR DESCRIPTION
In the testing pipeline, the serviceaccount and, most importantly, the monitoring namespace cannot be deleted, so specify the job to delete to steer away from deleting everything. Also, the tag for the locust-metrics-distributor must be hardcoded because we do not create a "latest" tag in build.sh. This should not be a problem for the amount of times we will be updating the locust-metrics-distributor docker image.