### PR TITLE
Add log dump for every locust test to s3

### DIFF
--- a/.circleci/locust.sh
+++ b/.circleci/locust.sh
@@ -70,10 +70,22 @@ then
   apply_chaos_after_sleep &
 fi
 
+START_TIME=$(date +%s)
+
 #run all tests
 run_locust $all_files
 
-#kill background metrics sending process
+# start a port-forward to get loki logs for the period of the test
+# TODO: this is not a good solution, but any other would be time consuming
+kubectl_run port-forward -n monitoring loki-0 3100:3100
+
+END_TIME=$(date +%s)
+
+#get logs from loki and store them in s3
+curl "localhost:3100/loki/api/v1/query_range?query=\{namespace=\"$APP\"\}&start=$START_TIME&end=$END_TIME&limit=10000" > logs.json
+aws_run s3 cp logs.json "s3://lasdpc-locust-results/$APP/logs-$START_TIME.json"
+
+#kill background metrics sending process and the local port-forward
 kill $(jobs -p)
 
 #set the metrics to zero before we exit to ensure no metrics linger with values


### PR DESCRIPTION
Add a simple way to store all logs generated by loki after a given test. This is a clear hack and not an ideal solution, but should work fine.

Note that the currently deployed loki instance does not match the configuration in the repository, as someone manually deployed a helm config without the extended log return limit and the line-separating regex. Because of a pending apply in terraform cloud I don't know what is about i didn't do this deployment it by myself.